### PR TITLE
Set PackageProjectUrl

### DIFF
--- a/src/libs/Directory.Build.props
+++ b/src/libs/Directory.Build.props
@@ -23,6 +23,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>nuget_icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/HavenDV/H.NotifyIcon</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup Label="Nuget">


### PR DESCRIPTION
Makes it easier to find the GitHub page from NuGet.

Example from Fody.Costura  
![image](https://user-images.githubusercontent.com/7112040/204190188-311fafb5-06db-437d-a3a7-65d215a64f07.png)  
vs  
![image](https://user-images.githubusercontent.com/7112040/204190243-78e89e85-363d-4000-822c-48883351c07d.png)
