### PR TITLE
Fixed IconSource in unpackaged not WPF apps

### DIFF
--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/TrayIconResources.xaml
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/TrayIconResources.xaml
@@ -112,13 +112,14 @@
         ContextMenuMode="SecondWindow"
         LeftClickCommand="{StaticResource ShowHideWindowCommand}"
         NoLeftClickDelay="True"
+        IconSource="\Assets\Red.ico"
         >
-        <tb:TaskbarIcon.GeneratedIcon>
+        <!--<tb:TaskbarIcon.GeneratedIcon>
             <tb:GeneratedIcon
                 Text="❤️"
                 Foreground="Red"
                 />
-        </tb:TaskbarIcon.GeneratedIcon>
+        </tb:TaskbarIcon.GeneratedIcon>-->
         <tb:TaskbarIcon.ContextFlyout>
             <MenuFlyout>
                 <MenuFlyoutItem Command="{StaticResource Command1}" />

--- a/src/libs/H.NotifyIcon.Shared/Utilities/ImageExtensions.cs
+++ b/src/libs/H.NotifyIcon.Shared/Utilities/ImageExtensions.cs
@@ -32,12 +32,14 @@ internal static class ImageExtensions
         using var stream = streamInfo.Stream;
         return stream.ToSmallIcon();
 #else
+#if IS_PACKABLE
         DesktopBridge.Helpers helpers = new DesktopBridge.Helpers();
         if (helpers.IsRunningAsUwp()) {
             var file = await StorageFile.GetFileFromApplicationUriAsync(uri);
             using var stream = await file.OpenStreamForReadAsync().ConfigureAwait(true);
             return stream.ToSmallIcon();
         } else {
+#endif
             string prefix = "";
             if (uri.Scheme == "ms-appx" || uri.Scheme == "ms-appx-web") {
                 prefix = AppContext.BaseDirectory;
@@ -47,7 +49,9 @@ internal static class ImageExtensions
             var absolutePath = $"{prefix}{uri.LocalPath}";
             using var fileStream = File.OpenRead(absolutePath);
             return fileStream.ToSmallIcon();
+#if IS_PACKABLE
         }
+#endif
 #endif
     }
 

--- a/src/libs/H.NotifyIcon.Uno.WinUI/H.NotifyIcon.Uno.WinUI.csproj
+++ b/src/libs/H.NotifyIcon.Uno.WinUI/H.NotifyIcon.Uno.WinUI.csproj
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
-    <DefineConstants>$(DefineConstants);HAS_UNO;HAS_WINUI</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_UNO;HAS_WINUI;IS_PACKABLE</DefineConstants>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);Uno0001;CA1010;CA1031</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DesktopBridge.Helpers" Version="1.2.2" />
     <PackageReference Include="Uno.WinUI" Version="4.4.13" />
   </ItemGroup>
 

--- a/src/libs/H.NotifyIcon.Uno/H.NotifyIcon.Uno.csproj
+++ b/src/libs/H.NotifyIcon.Uno/H.NotifyIcon.Uno.csproj
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
-    <DefineConstants>$(DefineConstants);HAS_UNO</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_UNO;IS_PACKABLE</DefineConstants>
     <NoWarn>$(NoWarn);Uno0001;CA1010;CA1031</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DesktopBridge.Helpers" Version="1.2.2" />
     <PackageReference Include="Uno.UI" Version="4.4.13" />
   </ItemGroup>
   

--- a/src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj
+++ b/src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0-windows10.0.17763.0</TargetFrameworks>
     <UseWinUI>true</UseWinUI>
-    <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_WINUI;IS_PACKABLE</DefineConstants>
     <NoWarn>$(NoWarn);CS3021;CA1031</NoWarn>
     <Nullable>enable</Nullable>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DesktopBridge.Helpers" Version="1.2.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.4" />
   </ItemGroup>
 

--- a/src/libs/H.NotifyIcon/H.NotifyIcon.csproj
+++ b/src/libs/H.NotifyIcon/H.NotifyIcon.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DesktopBridge.Helpers" Version="1.2.2" />
     <PackageReference Include="EventGenerator.Generator" Version="0.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/libs/H.NotifyIcon/H.NotifyIcon.csproj
+++ b/src/libs/H.NotifyIcon/H.NotifyIcon.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DesktopBridge.Helpers" Version="1.2.2" />
     <PackageReference Include="EventGenerator.Generator" Version="0.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
In an unpackaged app, there is no package context, so the old package depended implementation failed to load icon files.
This fix checks for package context at runtime and falls back to System.IO.File if running in unpackaged mode.

Fixes HavenDV/H.NotifyIcon#23