### PR TITLE
Sample code for the discussion on updating icon on the go

### DIFF
--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/App.xaml.cs
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/App.xaml.cs
@@ -7,6 +7,8 @@ public sealed partial class App
     public static TaskbarIcon? TrayIcon { get; private set; }
     public static Window? Window { get; set; }
 
+    public static bool option = false;
+
     #endregion
 
     #region Constructors
@@ -27,39 +29,52 @@ public sealed partial class App
 
     private void InitializeTrayIcon()
     {
-        var showHideWindowCommand = (XamlUICommand)Resources["ShowHideWindowCommand"];
-        showHideWindowCommand.ExecuteRequested += ShowHideWindowCommand_ExecuteRequested;
-
         var exitApplicationCommand = (XamlUICommand)Resources["ExitApplicationCommand"];
         exitApplicationCommand.ExecuteRequested += ExitApplicationCommand_ExecuteRequested;
 
+        var commandOne = (XamlUICommand)Resources["Command1"];
+        commandOne.ExecuteRequested += commandOne_ExecuteRequested;
+
         TrayIcon = (TaskbarIcon)Resources["TrayIcon"];
         TrayIcon.ForceCreate();
-    }
-
-    private void ShowHideWindowCommand_ExecuteRequested(object? _, ExecuteRequestedEventArgs args)
-    {
-        if (Window == null)
-        {
-            Window = new Window();
-            Window.Show();
-            return;
-        }
-
-        if (Window.Visible)
-        {
-            Window.Hide();
-        }
-        else
-        {
-            Window.Show();
-        }
     }
 
     private void ExitApplicationCommand_ExecuteRequested(object? _, ExecuteRequestedEventArgs args)
     {
         TrayIcon?.Dispose();
         Window?.Close();
+    }
+
+    private void commandOne_ExecuteRequested(object? _, ExecuteRequestedEventArgs args)
+    {
+        option = !option;
+        var commandOne = (XamlUICommand)Resources["Command1"];
+        if (option)
+        {
+            var iconHostOne = (XamlUICommand)Resources["IconHost1"];
+            commandOne.IconSource = iconHostOne.IconSource;
+            // This way works but as you can see it kind of a bad practice,
+            // I would like to be able to do like below instead:
+            // commandOne.IconSource.SymbolIconSource.Symbol = "Cancel";
+        }
+        else
+        {
+            var iconHostTwo = (XamlUICommand)Resources["IconHost2"];
+            commandOne.IconSource = iconHostTwo.IconSource;
+        }
+        // Also, I'm hoping it is possible to have an option like below,
+        // to make it easier for to toggle multiple options altogether:
+        // 
+        //   < XamlUICommand
+        //       x: Key = "Command0"
+        //       Label = "Command0"
+        //       Description = "Command0"
+        // --->  CloseMenuAfterClick = "False"
+        //       >
+        //       < XamlUICommand.IconSource >
+        //           < SymbolIconSource Symbol = "Cancel" />
+        //       </ XamlUICommand.IconSource >
+        //   </ XamlUICommand >
     }
 
     #endregion

--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/App.xaml.cs
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/App.xaml.cs
@@ -29,6 +29,9 @@ public sealed partial class App
 
     private void InitializeTrayIcon()
     {
+        var showHideWindowCommand = (XamlUICommand)Resources["ShowHideWindowCommand"];
+        showHideWindowCommand.ExecuteRequested += ShowHideWindowCommand_ExecuteRequested;
+
         var exitApplicationCommand = (XamlUICommand)Resources["ExitApplicationCommand"];
         exitApplicationCommand.ExecuteRequested += ExitApplicationCommand_ExecuteRequested;
 
@@ -37,6 +40,25 @@ public sealed partial class App
 
         TrayIcon = (TaskbarIcon)Resources["TrayIcon"];
         TrayIcon.ForceCreate();
+    }
+
+    private void ShowHideWindowCommand_ExecuteRequested(object? _, ExecuteRequestedEventArgs args)
+    {
+        if (Window == null)
+        {
+            Window = new Window();
+            Window.Show();
+            return;
+        }
+
+        if (Window.Visible)
+        {
+            Window.Hide();
+        }
+        else
+        {
+            Window.Show();
+        }
     }
 
     private void ExitApplicationCommand_ExecuteRequested(object? _, ExecuteRequestedEventArgs args)

--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/H.NotifyIcon.Apps.WinUI.Windowless.csproj
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/H.NotifyIcon.Apps.WinUI.Windowless.csproj
@@ -22,10 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="H.NotifyIcon" Version="2.0.77" />
-    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.77" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/H.NotifyIcon.Apps.WinUI.Windowless.csproj
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/H.NotifyIcon.Apps.WinUI.Windowless.csproj
@@ -22,6 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="H.NotifyIcon" Version="2.0.77" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.77" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
   </ItemGroup>
@@ -29,10 +31,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.25158-preview" />
     <Manifest Include="$(ApplicationManifest)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj" />
   </ItemGroup>
 
   <!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging

--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/H.NotifyIcon.Apps.WinUI.Windowless.csproj
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/H.NotifyIcon.Apps.WinUI.Windowless.csproj
@@ -25,14 +25,14 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\..\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.25158-preview" />
     <Manifest Include="$(ApplicationManifest)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj" />
   </ItemGroup>
 
   <!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging

--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/TrayIconResources.xaml
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/TrayIconResources.xaml
@@ -13,6 +13,69 @@
         </XamlUICommand.IconSource>
     </XamlUICommand>
     <XamlUICommand
+        x:Key="Command2"
+        Label="Command2"
+        Description="Command2"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="Admin" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="Command3"
+        Label="Command3"
+        Description="Command3"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="BrowsePhotos" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="Command4"
+        Label="Command4"
+        Description="Command4"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="FourBars" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="Command5"
+        Label="Command5"
+        Description="Command5"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="FourBars" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="Command6"
+        Label="Command6"
+        Description="Command6"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="FourBars" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="Command7"
+        Label="Command7"
+        Description="Command7"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="FourBars" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="Command8"
+        Label="Command8"
+        Description="Command8"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="FourBars" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
         x:Key="IconHost1"
         Label="IconHost1"
         Description="IconHost1"
@@ -29,6 +92,21 @@
         <XamlUICommand.IconSource>
             <SymbolIconSource Symbol="Admin" />
         </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="ShowHideWindowCommand"
+        Label="Show/Hide Window"
+        Description="Show/Hide Window"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="OpenPane" />
+        </XamlUICommand.IconSource>
+        <XamlUICommand.KeyboardAccelerators>
+            <KeyboardAccelerator
+                Key="S"
+                Modifiers="Control"
+                />
+        </XamlUICommand.KeyboardAccelerators>
     </XamlUICommand>
     <XamlUICommand
         x:Key="ExitApplicationCommand"
@@ -50,6 +128,7 @@
         Visibility="Visible"
         ToolTipText="ToolTip"
         ContextMenuMode="SecondWindow"
+        LeftClickCommand="{StaticResource ShowHideWindowCommand}"
         NoLeftClickDelay="True"
         IconSource="\Assets\Red.ico"
         >
@@ -62,6 +141,18 @@
         <tb:TaskbarIcon.ContextFlyout>
             <MenuFlyout>
                 <MenuFlyoutItem Command="{StaticResource Command1}" />
+                <MenuFlyoutSeparator />
+                <MenuFlyoutItem Command="{StaticResource Command2}" />
+                <MenuFlyoutSeparator />
+                <MenuFlyoutItem Command="{StaticResource Command3}" />
+                <MenuFlyoutSeparator />
+                <MenuFlyoutItem Command="{StaticResource Command4}" />
+                <MenuFlyoutItem Command="{StaticResource Command5}" />
+                <MenuFlyoutItem Command="{StaticResource Command6}" />
+                <MenuFlyoutItem Command="{StaticResource Command7}" />
+                <MenuFlyoutItem Command="{StaticResource Command8}" />
+                <MenuFlyoutSeparator />
+                <MenuFlyoutItem Command="{StaticResource ShowHideWindowCommand}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Command="{StaticResource ExitApplicationCommand}" />
             </MenuFlyout>

--- a/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/TrayIconResources.xaml
+++ b/src/apps/H.NotifyIcon.Apps.WinUI.Windowless/TrayIconResources.xaml
@@ -13,82 +13,22 @@
         </XamlUICommand.IconSource>
     </XamlUICommand>
     <XamlUICommand
-        x:Key="Command2"
-        Label="Command2"
-        Description="Command2"
+        x:Key="IconHost1"
+        Label="IconHost1"
+        Description="IconHost1"
+        >
+        <XamlUICommand.IconSource>
+            <SymbolIconSource Symbol="Cancel" />
+        </XamlUICommand.IconSource>
+    </XamlUICommand>
+    <XamlUICommand
+        x:Key="IconHost2"
+        Label="IconHost2"
+        Description="IconHost2"
         >
         <XamlUICommand.IconSource>
             <SymbolIconSource Symbol="Admin" />
         </XamlUICommand.IconSource>
-    </XamlUICommand>
-    <XamlUICommand
-        x:Key="Command3"
-        Label="Command3"
-        Description="Command3"
-        >
-        <XamlUICommand.IconSource>
-            <SymbolIconSource Symbol="BrowsePhotos" />
-        </XamlUICommand.IconSource>
-    </XamlUICommand>
-    <XamlUICommand
-        x:Key="Command4"
-        Label="Command4"
-        Description="Command4"
-        >
-        <XamlUICommand.IconSource>
-            <SymbolIconSource Symbol="FourBars" />
-        </XamlUICommand.IconSource>
-    </XamlUICommand>
-    <XamlUICommand
-        x:Key="Command5"
-        Label="Command5"
-        Description="Command5"
-        >
-        <XamlUICommand.IconSource>
-            <SymbolIconSource Symbol="FourBars" />
-        </XamlUICommand.IconSource>
-    </XamlUICommand>
-    <XamlUICommand
-        x:Key="Command6"
-        Label="Command6"
-        Description="Command6"
-        >
-        <XamlUICommand.IconSource>
-            <SymbolIconSource Symbol="FourBars" />
-        </XamlUICommand.IconSource>
-    </XamlUICommand>
-    <XamlUICommand
-        x:Key="Command7"
-        Label="Command7"
-        Description="Command7"
-        >
-        <XamlUICommand.IconSource>
-            <SymbolIconSource Symbol="FourBars" />
-        </XamlUICommand.IconSource>
-    </XamlUICommand>
-    <XamlUICommand
-        x:Key="Command8"
-        Label="Command8"
-        Description="Command8"
-        >
-        <XamlUICommand.IconSource>
-            <SymbolIconSource Symbol="FourBars" />
-        </XamlUICommand.IconSource>
-    </XamlUICommand>
-    <XamlUICommand
-        x:Key="ShowHideWindowCommand"
-        Label="Show/Hide Window"
-        Description="Show/Hide Window"
-        >
-        <XamlUICommand.IconSource>
-            <SymbolIconSource Symbol="OpenPane" />
-        </XamlUICommand.IconSource>
-        <XamlUICommand.KeyboardAccelerators>
-            <KeyboardAccelerator
-                Key="S"
-                Modifiers="Control"
-                />
-        </XamlUICommand.KeyboardAccelerators>
     </XamlUICommand>
     <XamlUICommand
         x:Key="ExitApplicationCommand"
@@ -110,7 +50,6 @@
         Visibility="Visible"
         ToolTipText="ToolTip"
         ContextMenuMode="SecondWindow"
-        LeftClickCommand="{StaticResource ShowHideWindowCommand}"
         NoLeftClickDelay="True"
         IconSource="\Assets\Red.ico"
         >
@@ -123,18 +62,6 @@
         <tb:TaskbarIcon.ContextFlyout>
             <MenuFlyout>
                 <MenuFlyoutItem Command="{StaticResource Command1}" />
-                <MenuFlyoutSeparator />
-                <MenuFlyoutItem Command="{StaticResource Command2}" />
-                <MenuFlyoutSeparator />
-                <MenuFlyoutItem Command="{StaticResource Command3}" />
-                <MenuFlyoutSeparator />
-                <MenuFlyoutItem Command="{StaticResource Command4}" />
-                <MenuFlyoutItem Command="{StaticResource Command5}" />
-                <MenuFlyoutItem Command="{StaticResource Command6}" />
-                <MenuFlyoutItem Command="{StaticResource Command7}" />
-                <MenuFlyoutItem Command="{StaticResource Command8}" />
-                <MenuFlyoutSeparator />
-                <MenuFlyoutItem Command="{StaticResource ShowHideWindowCommand}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Command="{StaticResource ExitApplicationCommand}" />
             </MenuFlyout>


### PR DESCRIPTION
For the discussion [here](https://github.com/HavenDV/H.NotifyIcon/discussions/62), as you suggested I've made a sample change for you to better understand my need.

> Hi, I'm new to XAML and am currently developing a similar thing, but got into a problem, may I ask how you ended up with the implementation?
> I was planning to change the icon of the items toggled between ✅ and ❎, but didn't find a way to do so. I also tried using binding but it didn't work, seems to be because my tray icon is saved in a ResourceDictionary, following the sample for WinUI.Windowless.
> Do you mind sharing on how your solution looks like?
>> It's cool that you thought of something like this, but I'm not sure if it's feasible without changes to the library. I could help you if you could provide a PR with a test application according to your ideas, and I would help with the implementation of this at the library level, if possible.