### PR TITLE
fix: PopupMenuSeparator is missing sometimes

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
@@ -58,8 +58,10 @@ public partial class TaskbarIcon
                         menuItems.Add(item);
                         break;
                     }
-                case MenuFlyoutSeparator:
+                case MenuFlyoutSeparator  separator:
                     {
+                        // The following line of code ensure that this code block is not trimed when PublishTrimmed is true.
+                        var a = separator;
                         menuItems.Add(new PopupMenuSeparator());
                         break;
                     }


### PR DESCRIPTION
PopupMenuSeparator is missing when PublishTrimmed is true(ContextMenuMode="PopupMenu"). 

Ensure that switch case block is not trimed