### PR TITLE
fix: Make sure MenuFlyout is displayed once before measure it

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -120,11 +120,26 @@ public partial class TaskbarIcon
 
         frame.Loaded += (_, _) =>
         {
+            bool flyoutLoaded = false;
+            flyout.Items.Last().Loaded += (_, _) => flyoutLoaded = true;
+
             flyout.ShowAt(window.Content, new FlyoutShowOptions
             {
                 ShowMode = FlyoutShowMode.Transient,
             });
-            flyout.Hide();
+
+            _ = Task.Run(async () =>
+            {
+                while (!flyoutLoaded)
+                {
+                    await Task.Delay(1).ConfigureAwait(false);
+                }
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    flyout.Items.Last().Loaded -= (_, _) => flyoutLoaded = true;
+                    flyout.Hide();
+                });
+            });
         };
         window.Activated += (sender, args) =>
         {


### PR DESCRIPTION
Make sure MenuFlyout is displayed once before measure it, so that we can get the correct MenuFlyoutItem's Width.

### some scenes before fix (only appear for the first time)
![image](https://user-images.githubusercontent.com/17621099/230189460-7c2bcd40-67ef-40f4-844d-ddf054a202d2.png)

### now
![image](https://user-images.githubusercontent.com/17621099/230189938-04c4c0d1-14dc-4b4b-b3a9-00a53009e2a5.png)

