### PR TITLE
Support Right-to-Left layout for PopupMenu and SecondWindow

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
@@ -10,7 +10,10 @@ public partial class TaskbarIcon
     [SupportedOSPlatform("windows5.1.2600")]
     private void ShowContextMenuInPopupMenuMode(System.Drawing.Point cursorPosition)
     {
-        var menu = new H.NotifyIcon.Core.PopupMenu();
+        var menu = new H.NotifyIcon.Core.PopupMenu
+        {
+            RightToLeft = FlowDirection == FlowDirection.RightToLeft
+        };
 #if HAS_MAUI
         PopulateMenu(menu.Items, (MenuFlyout)ContextFlyout);
 #else

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -1,4 +1,5 @@
 ﻿using H.NotifyIcon.Interop;
+using Microsoft.UI.Xaml.Data;
 
 namespace H.NotifyIcon;
 
@@ -60,6 +61,15 @@ public partial class TaskbarIcon
         {
             Background = new SolidColorBrush(Colors.Transparent),
         };
+
+        var flowDirectionBinding = new Binding
+        {
+            Source = this,
+            Path = new PropertyPath(nameof(FlowDirection)),
+            Mode = BindingMode.OneWay,
+        };
+        BindingOperations.SetBinding(frame, FlowDirectionProperty, flowDirectionBinding);
+
         var window = new Window()
         {
             Content = frame,

--- a/src/libs/H.NotifyIcon/PopupMenus/PopupMenu.cs
+++ b/src/libs/H.NotifyIcon/PopupMenus/PopupMenu.cs
@@ -19,6 +19,11 @@ public class PopupMenu
     /// <summary>
     /// 
     /// </summary>
+    public bool RightToLeft { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
     /// <param name="ownerHandle"></param>
     /// <param name="x"></param>
     /// <param name="y"></param>
@@ -29,6 +34,11 @@ public class PopupMenu
            TRACK_POPUP_MENU_FLAGS.TPM_RETURNCMD |
            TRACK_POPUP_MENU_FLAGS.TPM_NONOTIFY |
            TRACK_POPUP_MENU_FLAGS.TPM_BOTTOMALIGN;
+
+        if (RightToLeft)
+        {
+            flags |= TRACK_POPUP_MENU_FLAGS.TPM_LAYOUTRTL;
+        }
 
         BOOL id;
 


### PR DESCRIPTION
Add support for RTL layout to PopupMenu and SecondWindow scenarios.
![image](https://github.com/HavenDV/H.NotifyIcon/assets/126525910/fd0adcba-51a0-4280-b5c7-d9e3fd9c28d0)
![image](https://github.com/HavenDV/H.NotifyIcon/assets/126525910/ca9e55fd-75d9-44d8-8497-db8f2b8c83f4)
> [!note]
> ActiveWindow scenario is already weird and with `FlowDirection="RightToLeft"` it become even more weird.

> [!note]
> I've not checked Uno and MAUI cases since I don't have their tools installed on my machine.

This PR may fix #41 