### PR TITLE
Surface the TrayIcon Guid in TaskbarIcon

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
@@ -45,7 +45,7 @@ public partial class TaskbarIcon : FrameworkElement
     /// Note: Windows associates a Guid with the path of the binary, so you must use the new Guid when you change the path.
     /// </remarks>
     [SupportedOSPlatform("windows5.1.2600")]
-    public Guid? IsCreated => IsCreated ? TrayIcon.Id : null;
+    public Guid? Id => IsCreated ? TrayIcon.Id : null;
 
     #endregion
 

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
@@ -36,6 +36,17 @@ public partial class TaskbarIcon : FrameworkElement
     [SupportedOSPlatform("windows5.1.2600")]
     public bool IsCreated => TrayIcon.IsCreated;
 
+    /// <summary>
+    /// Unique ID. <br/>
+    /// It will be used by the system to store your TrayIcon settings, 
+    /// so it is recommended to make it fixed and unique for each application TrayIcon, not random.
+    /// </summary>
+    /// <remarks>
+    /// Note: Windows associates a Guid with the path of the binary, so you must use the new Guid when you change the path.
+    /// </remarks>
+    [SupportedOSPlatform("windows5.1.2600")]
+    public Guid? IsCreated => IsCreated ? TrayIcon.Id : null;
+
     #endregion
 
     #region Constructors


### PR DESCRIPTION
Currently, it's impossible to get the NotifyIcon GUID from the library, in case you want to use [NotifyIconGetRect](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyicongetrect) or others. (well, unless you use reflection..)  

This PR adds a simple bridge property to help with that. 