### PR TITLE
Add `DynamicDependency` attributes for non-public constructors

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
@@ -1,4 +1,6 @@
-﻿namespace H.NotifyIcon;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace H.NotifyIcon;
 
 public partial class TaskbarIcon
 {
@@ -8,6 +10,7 @@ public partial class TaskbarIcon
     /// Displays the ContextMenu/ContextFlyout if it was set.
     /// </summary>
     [SupportedOSPlatform("windows5.1.2600")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyout))]
     private void ShowContextMenuInPopupMenuMode(System.Drawing.Point cursorPosition)
     {
         var menu = new H.NotifyIcon.Core.PopupMenu
@@ -31,6 +34,10 @@ public partial class TaskbarIcon
 #endif
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(ToggleMenuFlyoutItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutSeparator))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutSubItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutItem))]
     private static void PopulateMenu(ICollection<PopupItem> menuItems, IList<MenuFlyoutItemBase> flyoutItemBases)
     {
         foreach (var flyoutItemBase in flyoutItemBases)

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
@@ -1,4 +1,6 @@
-﻿namespace H.NotifyIcon;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace H.NotifyIcon;
 
 [DependencyProperty<ContextMenuMode>("ContextMenuMode", DefaultValue = ContextMenuMode.PopupMenu,
     Description = "Defines the context menu mode.", Category = CategoryName)]
@@ -76,10 +78,12 @@ public partial class TaskbarIcon
 #endif
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyout))]
     private void UpdateContextFlyoutDataContext(
         FlyoutBase flyout,
         object? newValue)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutSubItem))]
         void UpdateMenuFlyoutDataContext(MenuFlyoutItemBase item)
         {
             UpdateDataContext(item, newValue);

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -1,4 +1,5 @@
-﻿using H.NotifyIcon.Interop;
+﻿using System.Diagnostics.CodeAnalysis;
+using H.NotifyIcon.Interop;
 using Microsoft.UI.Xaml.Data;
 
 namespace H.NotifyIcon;
@@ -49,6 +50,10 @@ public partial class TaskbarIcon
         _ = WindowUtilities.SetForegroundWindow(ContextMenuWindowHandle.Value);
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(OverlappedPresenter))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyout))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutSeparator))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutSubItem))]
     private void PrepareContextMenuWindow()
     {
         if (ContextFlyout == null ||
@@ -178,6 +183,7 @@ public partial class TaskbarIcon
         ContextMenuFlyout = flyout;
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutSeparator))]
     private static Size MeasureFlyout(MenuFlyout flyout, Size availableSize)
     {
         var width = 0.0;

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Popups.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Popups.cs
@@ -1,4 +1,6 @@
-﻿namespace H.NotifyIcon;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace H.NotifyIcon;
 
 #if !HAS_MAUI
 [DependencyProperty<PopupActivationMode>("PopupActivation", DefaultValue = PopupActivationMode.LeftClick,
@@ -67,6 +69,7 @@ public partial class TaskbarIcon
     /// placed under the mouse. ToolTip internally uses a Popup of
     /// its own, but takes advance of Popup's internal <see cref="UIElement.IsHitTestVisible"/>
     /// property which prevents this issue.</remarks>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(Popup))]
     private void CreatePopup()
     {
         // check if the item itself is a popup

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ToolTips.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ToolTips.cs
@@ -1,4 +1,6 @@
-﻿namespace H.NotifyIcon;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace H.NotifyIcon;
 
 [DependencyProperty<string>("ToolTipText", DefaultValue = "",
     Description = "A tooltip text that is being displayed if no custom ToolTip was set or if custom tooltips are not supported.", Category = CategoryName)]
@@ -104,6 +106,7 @@ public partial class TaskbarIcon
     /// placed under the mouse. ToolTip internally uses a Popup of
     /// its own, but takes advance of Popup's internal IsHitTestVisible
     /// property which prevents this issue.</remarks>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(ToolTip2))]
     private void CreateCustomToolTip()
     {
 #if !MACOS && !HAS_MAUI

--- a/src/libs/H.NotifyIcon.Shared/Utilities/ImageExtensions.WinRT.cs
+++ b/src/libs/H.NotifyIcon.Shared/Utilities/ImageExtensions.WinRT.cs
@@ -1,4 +1,6 @@
-﻿namespace H.NotifyIcon;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace H.NotifyIcon;
 
 /// <summary>
 /// Provides WinRT-specific extension methods for converting ImageSource objects and URIs to streams.
@@ -59,6 +61,7 @@ public static partial class ImageExtensions
     /// <exception cref="NotImplementedException">Thrown when the ImageSource type is not supported.</exception>
     /// <exception cref="FileNotFoundException">Thrown when the image file is not found.</exception>
     [CLSCompliant(false)]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(BitmapImage))]
     public static Stream ToStream(this ImageSource imageSource)
     {
         imageSource = imageSource ?? throw new ArgumentNullException(nameof(imageSource));
@@ -88,6 +91,7 @@ public static partial class ImageExtensions
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
     /// <exception cref="FileNotFoundException">Thrown when the image file is not found.</exception>
     [CLSCompliant(false)]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(BitmapImage))]
     public static async Task<Stream> ToStreamAsync(this ImageSource imageSource, CancellationToken cancellationToken = default)
     {
         imageSource = imageSource ?? throw new ArgumentNullException(nameof(imageSource));

--- a/src/libs/H.NotifyIcon.Shared/Utilities/System.Drawing/ConvertToExtensions.cs
+++ b/src/libs/H.NotifyIcon.Shared/Utilities/System.Drawing/ConvertToExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace H.NotifyIcon;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace H.NotifyIcon;
 
 internal static class ToSystemDrawingExtensions
 {
@@ -31,6 +33,8 @@ internal static class ToSystemDrawingExtensions
     }
 
     [SupportedOSPlatform("windows")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(SolidColorBrush))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(LinearGradientBrush))]
     internal static System.Drawing.Brush ToSystemDrawingBrush(this Brush? brush)
     {
         return brush switch

--- a/src/libs/H.NotifyIcon/PopupMenus/TrayIconWithContextMenu.cs
+++ b/src/libs/H.NotifyIcon/PopupMenus/TrayIconWithContextMenu.cs
@@ -7,7 +7,7 @@ namespace H.NotifyIcon.Core;
 
 /// <inheritdoc/>
 [SupportedOSPlatform("windows5.1.2600")]
-public class TrayIconWithContextMenu : TrayIcon
+public partial class TrayIconWithContextMenu : TrayIcon
 {
     /// <summary>
     /// 


### PR DESCRIPTION
Fixes #212.

This is a workaround for a trimming issue in CsWinRT (e.g. see https://github.com/microsoft/CsWinRT/issues/2068). This PR manually applies the right `[DynamicDependency]` attributes on all location where CsWinRT 2.3 would emit a warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal trimming hints to improve app optimization and runtime performance.
  * Refactored internal code structure for better compatibility with .NET optimization tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->