### PR TITLE
Fix missing System.Drawing assembly reference

### DIFF
--- a/src/libs/H.NotifyIcon.Maui/H.NotifyIcon.Maui.csproj
+++ b/src/libs/H.NotifyIcon.Maui/H.NotifyIcon.Maui.csproj
@@ -57,4 +57,8 @@ popups, context menus, and balloon messages. It can be used directly in code or 
     <ProjectReference Include="..\H.NotifyIcon\H.NotifyIcon.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0' OR '$(TargetFramework)' == 'net10.0-windows10.0.19041.0'">
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/libs/H.NotifyIcon.Uno.WinUI/H.NotifyIcon.Uno.WinUI.csproj
+++ b/src/libs/H.NotifyIcon.Uno.WinUI/H.NotifyIcon.Uno.WinUI.csproj
@@ -57,4 +57,8 @@ popups, context menus, and balloon messages. It can be used directly in code or 
     <PackageReference Include="Uno.WinUI" Version="6.4.185" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0' OR '$(TargetFramework)' == 'net10.0-windows10.0.19041'">
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/libs/H.NotifyIcon.Uno/H.NotifyIcon.Uno.csproj
+++ b/src/libs/H.NotifyIcon.Uno/H.NotifyIcon.Uno.csproj
@@ -37,4 +37,8 @@ popups, context menus, and balloon messages. It can be used directly in code or 
     <ProjectReference Include="..\H.NotifyIcon\H.NotifyIcon.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj
+++ b/src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj
@@ -40,4 +40,8 @@ popups, context menus, and balloon messages. It can be used directly in code or 
     <ProjectReference Include="..\H.NotifyIcon\H.NotifyIcon.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.17763.0'">
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/libs/H.NotifyIcon.Wpf/H.NotifyIcon.Wpf.csproj
+++ b/src/libs/H.NotifyIcon.Wpf/H.NotifyIcon.Wpf.csproj
@@ -64,4 +64,8 @@ popups, context menus, and balloon messages. It can be used directly in code or 
     <ProjectReference Include="..\H.NotifyIcon\H.NotifyIcon.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Added System.Drawing.Common 10.0.0 package reference to all platform projects that compile shared System.Drawing source files. This fixes the IImage type reference error in GeneratedIconSource.System.Drawing.cs for .NET 10 target frameworks.

Projects updated:
- H.NotifyIcon.Wpf (net10.0-windows)
- H.NotifyIcon.WinUI (net10.0-windows10.0.17763.0)
- H.NotifyIcon.Uno (net10.0)
- H.NotifyIcon.Uno.WinUI (net10.0, net10.0-windows10.0.19041)
- H.NotifyIcon.Maui (net10.0, net10.0-windows10.0.19041.0)

Resolves: Assembly reference to System.Private.Windows.GdiPlus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added System.Drawing.Common dependency support for .NET 10.0 builds across platform-specific libraries to ensure compatibility with the latest framework version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->