### PR TITLE
Add workaround for dotnet/wpf#11246

### DIFF
--- a/src/libs/Directory.Build.targets
+++ b/src/libs/Directory.Build.targets
@@ -34,5 +34,15 @@
     <Compile Remove="$(MSBuildThisFileDirectory)**\*.Maui.*" />
     <Compile Remove="$(MSBuildThisFileDirectory)**\Maui\*.*" />
   </ItemGroup>
+
+  <!-- Workaround for https://github.com/dotnet/wpf/issues/11246 -->
+  <Target Name="FixWpfReferences" AfterTargets="ResolveTargetingPackAssets" Condition="'$(UseWPF)' == 'true'">
+    <ItemGroup>
+      <SystemPrivateWindowsCoreRef Include="@(Reference)" Condition="'%(Filename)' == 'System.Private.Windows.Core'" />
+        <ReferencePath Include="@(SystemPrivateWindowsCoreRef->'%(RootDir)%(Directory)System.Private.Windows.GdiPlus.dll')">
+        <AssemblyName>System.Private.Windows.GdiPlus</AssemblyName>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
   
 </Project>


### PR DESCRIPTION
.NET 10 WPF builds fail due to missing `System.Private.Windows.GdiPlus` reference. This is a known issue tracked at https://github.com/dotnet/wpf/issues/11246.

### Changes

- Added `FixWpfReferences` MSBuild target to `src/libs/Directory.Build.targets`
- Target runs after `ResolveTargetingPackAssets` for WPF projects only
- Automatically adds the missing GdiPlus assembly reference derived from the Core assembly path

```xml
<!-- Workaround for https://github.com/dotnet/wpf/issues/11246 -->
<Target Name="FixWpfReferences" AfterTargets="ResolveTargetingPackAssets" Condition="'$(UseWPF)' == 'true'">
    <ItemGroup>
        <SystemPrivateWindowsCoreRef Include="@(Reference)" Condition="'%(Filename)' == 'System.Private.Windows.Core'" />
        <ReferencePath Include="@(SystemPrivateWindowsCoreRef->'%(RootDir)%(Directory)System.Private.Windows.GdiPlus.dll')">
            <AssemblyName>System.Private.Windows.GdiPlus</AssemblyName>
        </ReferencePath>
    </ItemGroup>
</Target>
```

This is a temporary workaround until the upstream fix is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced build configuration to resolve WPF project assembly reference issues, ensuring more reliable builds for projects using Windows Presentation Foundation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->