### PR TITLE
fix: Make ResetBalloonCloseTimer work with native notifications

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
@@ -120,6 +120,9 @@ public partial class TaskbarIcon : IDisposable
 #if HAS_WPF
             balloonCloseTimer.Dispose();
 #endif
+#if !MACOS
+            nativeBalloonRefreshTimer?.Dispose();
+#endif
 
 #if !HAS_WPF && !HAS_UNO && !HAS_MAUI
             ContextMenuWindow?.Close();

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
@@ -89,6 +89,10 @@ public partial class TaskbarIcon : FrameworkElement
         balloonCloseTimer = new Timer(CloseBalloonCallback);
 #endif
 
+#if !MACOS
+        nativeBalloonRefreshTimer = new Timer(_ => RefreshNativeBalloon());
+#endif
+
         DisposeAfterExit();
     }
 


### PR DESCRIPTION
## Summary

Fixed issue where `ResetBalloonCloseTimer()` didn't work with native Windows notifications shown via `ShowNotification()`.

## Changes

- Added timer to periodically refresh native balloon notifications
- Track last notification parameters for refresh
- Update `ResetBalloonCloseTimer()` to handle both custom and native balloons
- Refresh native notifications every 25 seconds to keep them visible indefinitely
- Stop refresh timer when balloon is closed or notifications are cleared

Fixes #220

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced native notification visibility on non-Mac platforms with automatic periodic refresh (every 25 seconds) to prevent notifications from disappearing prematurely.
  * Improved notification state tracking and lifecycle management for better application stability.
  * Refined resource cleanup with proper disposal of notification timers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->