### PR TITLE
fix: Remove duplicate target frameworks from project files

### DIFF
--- a/H.NotifyIcon.slnx
+++ b/H.NotifyIcon.slnx
@@ -1,4 +1,4 @@
-﻿<Solution>
+<Solution>
   <Configurations>
     <Platform Name="Any CPU" />
     <Platform Name="arm64" />
@@ -32,6 +32,7 @@
       <Configuration Solution="Release|arm64" Project="Release|arm64|Deploy" />
       <Configuration Solution="Release|x64" Project="Release|x64|Deploy" />
       <Configuration Solution="Release|x86" Project="Release|x86|Deploy" />
+      <Platform Solution="Debug|Any CPU" Project="x64" />
     </Project>
     <Project Path="src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj">
       <Configuration Solution="Debug|Any CPU" Project="Debug|x64|Deploy" />
@@ -42,6 +43,7 @@
       <Configuration Solution="Release|arm64" Project="Release|arm64|Deploy" />
       <Configuration Solution="Release|x64" Project="Release|x64|Deploy" />
       <Configuration Solution="Release|x86" Project="Release|x86|Deploy" />
+      <Platform Solution="Debug|Any CPU" Project="x64" />
     </Project>
     <Project Path="src\apps\H.NotifyIcon.Apps.Wpf.Windowless\H.NotifyIcon.Apps.Wpf.Windowless.csproj">
       <Configuration Solution="Debug|arm64" Project="Debug|Any CPU" />

--- a/src/libs/H.GeneratedIcons.SkiaSharp/H.GeneratedIcons.SkiaSharp.csproj
+++ b/src/libs/H.GeneratedIcons.SkiaSharp/H.GeneratedIcons.SkiaSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.6.2;netstandard2.0;net10.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net4.6.2;netstandard2.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libs/H.GeneratedIcons.System.Drawing/H.GeneratedIcons.System.Drawing.csproj
+++ b/src/libs/H.GeneratedIcons.System.Drawing/H.GeneratedIcons.System.Drawing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.6.2;netstandard2.0;net10.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net4.6.2;netstandard2.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Usings">

--- a/src/libs/H.NotifyIcon.Maui/H.NotifyIcon.Maui.csproj
+++ b/src/libs/H.NotifyIcon.Maui/H.NotifyIcon.Maui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>

--- a/src/libs/H.NotifyIcon.Uno.WinUI/H.NotifyIcon.Uno.WinUI.csproj
+++ b/src/libs/H.NotifyIcon.Uno.WinUI/H.NotifyIcon.Uno.WinUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <DefineConstants>$(DefineConstants);HAS_WINUI;IS_PACKABLE;HAS_PLATFORM_CODE</DefineConstants>
     <DefineConstants Condition=" '$(TargetFramework)' != 'net10.0-windows10.0.19041' ">$(DefineConstants);HAS_UNO</DefineConstants>

--- a/src/libs/H.NotifyIcon.Uno/H.NotifyIcon.Uno.csproj
+++ b/src/libs/H.NotifyIcon.Uno/H.NotifyIcon.Uno.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <DefineConstants>$(DefineConstants);HAS_UNO;IS_PACKABLE;HAS_PLATFORM_CODE</DefineConstants>
     <NoWarn>$(NoWarn);Uno0001;Uno0002;CA1010;CA1031;CS8002;CA1416;CA1063;CA1513;CA2000;CS0114;CS3009</NoWarn>

--- a/src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj
+++ b/src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0-windows10.0.17763.0;net10.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-windows10.0.17763.0</TargetFrameworks>
     <UseWinUI>true</UseWinUI>
     <DefineConstants>$(DefineConstants);HAS_WINUI;IS_PACKABLE;HAS_PLATFORM_CODE</DefineConstants>
     <NoWarn>$(NoWarn);CS3021;CA1031;CS8002;CA1513;NETSDK1206</NoWarn>

--- a/src/libs/H.NotifyIcon.Wpf/H.NotifyIcon.Wpf.csproj
+++ b/src/libs/H.NotifyIcon.Wpf/H.NotifyIcon.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.6.2;net10.0-windows;net10.0-windows</TargetFrameworks>
+    <TargetFrameworks>net4.6.2;net10.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <DefineConstants>$(DefineConstants);HAS_WPF;HAS_PLATFORM_CODE</DefineConstants>
     <RootNamespace>Hardcodet.Wpf.TaskbarNotification</RootNamespace>

--- a/src/libs/H.NotifyIcon/H.NotifyIcon.csproj
+++ b/src/libs/H.NotifyIcon/H.NotifyIcon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.6.2;netstandard2.0;net10.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net4.6.2;netstandard2.0;net10.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1031;CA1003;CA1502;CS3016;CS8981;CA1513</NoWarn>
     <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute</PolySharpExcludeGeneratedTypes>
   </PropertyGroup>


### PR DESCRIPTION
- Cleaned up project files by removing repeated target frameworks, ensuring clearer configuration and avoiding potential build failures.
- The WinUI Apps automatically set to build as x86 in Configuration Manager - Changed to be x64.

This PR fixes issue cited in #224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations for WinUI applications to support Debug platform targeting on x64.
  * Removed duplicate target framework entries from multiple library projects including icon generation utilities, core notification libraries, and platform-specific implementations to maintain consistent and clean project configurations throughout the solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->