### PR TITLE
fix(secondwindow): animate context menu from correct direction

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -52,6 +52,29 @@ public partial class TaskbarIcon
             (int)size.Height,
             excludeRect);
 
+        // Choose placement so WinUI's MenuPopupThemeTransition runs the open
+        // animation from the correct direction: only Top placement produces
+        // the bottom-up slide. Offset the rectangle by its own height to
+        // compensate for Top/Bottom placing the flyout adjacent to the anchor
+        // rather than overlapping it.
+        if (rectangle.Y + rectangle.Height <= cursorPosition.Y)
+        {
+            // Menu extends above the cursor (bottom-taskbar case).
+            ContextMenuFlyout.Placement = FlyoutPlacementMode.Top;
+            rectangle.Y += rectangle.Height;
+        }
+        else if (rectangle.Y >= cursorPosition.Y)
+        {
+            // Menu extends below the cursor (top-taskbar case).
+            ContextMenuFlyout.Placement = FlyoutPlacementMode.Bottom;
+            rectangle.Y -= rectangle.Height;
+        }
+        else
+        {
+            // Horizontal taskbar — preserve existing Full placement.
+            ContextMenuFlyout.Placement = FlyoutPlacementMode.Full;
+        }
+
         IsContextMenuVisible = true;
         ContextMenuAppWindow?.MoveAndResize(rectangle.ToRectInt32());
         _ = WindowUtilities.ShowWindow(ContextMenuWindowHandle.Value);


### PR DESCRIPTION
# fix(secondwindow): animate context menu from correct direction

## Summary

On a bottom taskbar (the Windows default) the `SecondWindow` context menu visually extends upward from the cursor, but the open animation slides **top-down** — producing a directional mismatch the user notices as a "wrong-way" animation. On a top taskbar the symmetric problem appears. This PR makes the animation slide in from the correct side by choosing `Placement` per-show, with no change to the final rendered position.

## Problem

`ShowContextMenuInSecondWindowMode` relied on the flyout's initialized `Placement` of `FlyoutPlacementMode.Full` and never reassigned it. WinUI's `MenuFlyout` open-animation direction is set in `MenuFlyout::PreparePopupTheme` ([microsoft-ui-xaml/src/dxaml/xcp/dxaml/lib/MenuFlyout_Partial.cpp](https://github.com/microsoft/microsoft-ui-xaml/blob/main/src/dxaml/xcp/dxaml/lib/MenuFlyout_Partial.cpp)):

```cpp
direction = (placementMode == MajorPlacementMode::Top)
    ? AnimationDirection_Bottom   // bottom-up slide
    : AnimationDirection_Top;     // top-down slide
```

Only `MajorPlacementMode::Top` triggers the bottom-up slide. `Full` (and every other value) falls through to the top-down slide regardless of where the helper window actually lands on screen. Result: on the default bottom-taskbar layout, the menu visually extends upward but animates downward.

## Investigation

1. Confirmed in the WinUI source that animation direction is derived from `MajorPlacementMode` via the call above, and that `FlyoutPlacementMode.Top` maps to `MajorPlacementMode::Top` through `GetMajorPlacementFromPlacement` in `FlyoutBase_partial.cpp`.
2. Confirmed in `TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs` that `ContextMenuFlyout.Placement` is hardcoded to `Full` in `PrepareContextMenuWindow` and never reassigned before show.
3. Prototyped the fix in a consuming app via reflection on the private `ContextMenuFlyout` property and confirmed two things end-to-end:
   - Setting `Placement = Top` flips the animation direction to bottom-up, matching the direction the menu visually extends.
   - Setting `Placement = Top` also causes WinUI to render the flyout `anchor.Height` pixels *above* the anchor (because `Top` positions the flyout *adjacent to* rather than *overlapping* the anchor), which introduces a Y offset.
4. Verified that offsetting the helper window down by its own height before `MoveAndResize` compensates exactly, producing a pixel-identical final position with the correct animation. Confirmed via logging `rectangle.Y` and `rectangle.Height` across ~10 right-clicks: the shift is exactly `rectangle.Height` every time and the menu lands in the original location.

## What changed

`ShowContextMenuInSecondWindowMode` now chooses `Placement` per-show based on the direction the popup extends relative to the cursor, and offsets the target rectangle by its own height when a `Top`/`Bottom` placement is used:

```csharp
if (rectangle.Y + rectangle.Height <= cursorPosition.Y)
{
    // Menu extends above the cursor (bottom-taskbar case).
    ContextMenuFlyout.Placement = FlyoutPlacementMode.Top;
    rectangle.Y += rectangle.Height;
}
else if (rectangle.Y >= cursorPosition.Y)
{
    // Menu extends below the cursor (top-taskbar case).
    ContextMenuFlyout.Placement = FlyoutPlacementMode.Bottom;
    rectangle.Y -= rectangle.Height;
}
else
{
    // Horizontal taskbar — preserve existing Full placement.
    ContextMenuFlyout.Placement = FlyoutPlacementMode.Full;
}
```

No changes to `PrepareContextMenuWindow`, `MeasureFlyout`, `ShowSecondWindowFlyout`, or any event wiring. No new reflection, no new dependencies, no new public surface.

## Reasoning

- **Why per-show** — the correct direction depends on where `CalculatePopupWindowPosition` lands each time; at `PrepareContextMenuWindow` time the window position isn't known yet.
- **Why offset by `rectangle.Height`** — the helper window is sized identically to the flyout, so `anchor.Height == flyout.Height`. `Top` placement positions the flyout one `anchor.Height` above the anchor, and `Bottom` one `anchor.Height` below. Offsetting the helper window by its own height in the opposite direction cancels this out precisely.
- **Why the horizontal case is left alone** — `MenuPopupThemeTransition::CreateStoryboardImpl` only defines vertical animation directions. Left/Right placements would inherit the default top-down animation anyway, so there's nothing meaningful to "correct" horizontally. Preserving the existing `Full` behavior avoids regressing an untested scenario.

## Testing

Manual testing on Windows 11 with a bottom taskbar (the only taskbar position Windows 11 supports natively):

- **Before fix:** open animation slides top-down while the menu visually extends upward — visible mismatch.
- **After fix:** open animation slides bottom-up. Final menu position is pixel-identical to before, verified by logging `rectangle.Y` and `rectangle.Height` before and after the shift across ~10 right-clicks — shift equals `rectangle.Height` every time.
- **Menu items, submenus, left-click behavior, close behavior, balloon notifications:** all unchanged.
- Verified via a local `ProjectReference` build of `H.NotifyIcon.WinUI` against a consuming WinUI 3 test app (not the reflection prototype).
- **Top-taskbar and horizontal-taskbar cases:** not tested on hardware — Windows 11 doesn't support those positions natively. Top-taskbar logic mirrors the bottom-taskbar path symmetrically; horizontal cases intentionally fall through to the existing `Full` behavior with no change.

## Notes for reviewer

- Single conditional block inside `ShowContextMenuInSecondWindowMode`; +23 lines, 0 removed.
- No reflection, no new events, no new dependencies, no trim/AOT concerns.
- Does not introduce ``[DynamicDependency]`` requirements — `ContextMenuFlyout` is already reachable in the same class.
- Related upstream issues (for context, not blocking):
  - [microsoft-ui-xaml#6126 — Proposal: FlyoutShowOptions.Placement and FlyoutShowOptions.Position interaction](https://github.com/microsoft/microsoft-ui-xaml/issues/6126)
  - [microsoft-ui-xaml#6869 — MenuFlyout and CommandBarFlyout have different opening animation](https://github.com/microsoft/microsoft-ui-xaml/issues/6869)