### PR TITLE
[codex] Fix PNG IconSource conversion

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/Utilities/System.Drawing/StreamExtensions.cs
+++ b/src/libs/H.NotifyIcon.Shared/Utilities/System.Drawing/StreamExtensions.cs
@@ -8,8 +8,8 @@ internal static class StreamExtensions
     internal static Icon ToSmallIcon(this Stream stream)
     {
         var iconSize = IconUtilities.GetRequiredCustomIconSize(largeIcon: false).ScaleWithDpi();
-
-        return new Icon(stream, iconSize);
+        using var iconStream = stream.ToIconStream();
+        return new Icon(iconStream, iconSize);
     }
     
     [SupportedOSPlatform("windows")]
@@ -24,5 +24,35 @@ internal static class StreamExtensions
         using var image = System.Drawing.Image.FromStream(stream);
         
         return (image.Width, image.Height, System.Drawing.Image.GetPixelFormatSize(image.PixelFormat));
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static MemoryStream ToIconStream(this Stream stream)
+    {
+        if (stream == null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+
+        var data = buffer.ToArray();
+        var iconData = IsPng(data) ? data.ConvertPngToIco() : data;
+
+        return new MemoryStream(iconData, writable: false);
+    }
+
+    private static bool IsPng(byte[] data)
+    {
+        return data.Length >= 8 &&
+               data[0] == 0x89 &&
+               data[1] == 0x50 &&
+               data[2] == 0x4E &&
+               data[3] == 0x47 &&
+               data[4] == 0x0D &&
+               data[5] == 0x0A &&
+               data[6] == 0x1A &&
+               data[7] == 0x0A;
     }
 }


### PR DESCRIPTION
## Summary
- normalize icon streams before constructing `System.Drawing.Icon`
- convert raw PNG image data to ICO data for tray icon creation
- cover both sync and async `IconSource` paths through the shared stream helper

## Why
`TaskbarIcon.OnIconSourceChanged` uses `ToIconAsync()`, which previously passed raw PNG streams into `System.Drawing.Icon`. That works for `.ico` content but throws for `BitmapImage` sources backed by PNG files, which is the failure reported in #208.

## Validation
- `dotnet build src/libs/H.NotifyIcon/H.NotifyIcon.csproj --configuration Release /p:GeneratePackageOnBuild=false`
- `dotnet build src/libs/H.NotifyIcon.Wpf/H.NotifyIcon.Wpf.csproj --configuration Release /p:GeneratePackageOnBuild=false`

Fixes #208
