### PR TITLE
[codex] Fall back when process path inspection fails

### DIFF
--- a/src/libs/H.NotifyIcon/Core/TrayIcon.cs
+++ b/src/libs/H.NotifyIcon/Core/TrayIcon.cs
@@ -227,14 +227,22 @@ public partial class TrayIcon : IDisposable
             return processPath;
         }
 #endif
-        using (var process = Process.GetCurrentProcess())
+        try
         {
-            var path = process?.MainModule?.FileName;
-            if (path != null &&
-                !string.IsNullOrWhiteSpace(path))
+            using var process = Process.GetCurrentProcess();
+            var path = process.MainModule?.FileName;
+            if (!string.IsNullOrWhiteSpace(path))
             {
-                return path;
+                return path!;
             }
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Some endpoint protection tools block MainModule inspection.
+        }
+        catch (InvalidOperationException)
+        {
+            // Fall back to assembly/AppContext probing when process metadata is unavailable.
         }
         
         var assembly =


### PR DESCRIPTION
## Summary
- stop treating `Process.MainModule` as a hard requirement when deriving the tray icon GUID
- fall back to the existing assembly/AppContext path resolution when process inspection throws
- keep the change limited to the shared process-path helper used by tray icon initialization

## Why
On some systems, endpoint protection or memory-protection features cause `Process.MainModule` to throw while `TaskbarIcon` is initializing. That currently crashes the constructor path even though the library already has alternate ways to derive a stable process path.

## Validation
- `dotnet build src/libs/H.NotifyIcon/H.NotifyIcon.csproj --configuration Release /p:GeneratePackageOnBuild=false`
- `dotnet build src/libs/H.NotifyIcon.Wpf/H.NotifyIcon.Wpf.csproj --configuration Release /p:GeneratePackageOnBuild=false`

Fixes #188
