### PR TITLE
[codex] Keep SUBCLASSPROC delegates rooted per window

### DIFF
--- a/src/libs/H.NotifyIcon/Core/WindowUtilities.cs
+++ b/src/libs/H.NotifyIcon/Core/WindowUtilities.cs
@@ -1,4 +1,5 @@
-﻿using H.NotifyIcon.Interop;
+﻿using System.Collections.Concurrent;
+using H.NotifyIcon.Interop;
 
 namespace H.NotifyIcon.Core;
 
@@ -8,6 +9,8 @@ namespace H.NotifyIcon.Core;
 [SupportedOSPlatform("windows5.0")]
 public static class WindowUtilities
 {
+    private const uint WindowNcDestroy = 0x0082;
+
     /// <summary>
     /// Starts message processing on the current thread and blocks it until a WM_QUIT message or error is received.
     /// </summary>
@@ -136,12 +139,13 @@ public static class WindowUtilities
     public static unsafe void MakeTransparent(nint hWndHandle)
     {
         var hWnd = new HWND(hWndHandle);
-
-        SubClassDelegate = new SUBCLASSPROC(WindowSubClass);
+        var subClassDelegate = SubClassDelegates.GetOrAdd(
+            hWndHandle,
+            static _ => new SUBCLASSPROC(WindowSubClass));
 
         _ = PInvoke.SetWindowSubclass(
             hWnd: hWnd,
-            pfnSubclass: SubClassDelegate,
+            pfnSubclass: subClassDelegate,
             uIdSubclass: 0,
             dwRefData: 0).EnsureNonZero();
 
@@ -162,13 +166,18 @@ public static class WindowUtilities
     
     private static int ToWin32(System.Drawing.Color c) => (int) c.B << 16 | (int) c.G << 8 | (int) c.R;
     
-    private static SUBCLASSPROC? SubClassDelegate;
+    private static readonly ConcurrentDictionary<nint, SUBCLASSPROC> SubClassDelegates = new();
 
     [SupportedOSPlatform("windows5.1.2600")]
     private static unsafe LRESULT WindowSubClass(HWND hWnd, uint uMsg, WPARAM wParam, LPARAM lParam, nuint uIdSubclass, nuint dwRefData)
     {
         switch (uMsg)
         {
+            case WindowNcDestroy:
+                {
+                    _ = SubClassDelegates.TryRemove((nint)hWnd.Value, out _);
+                    break;
+                }
             case PInvoke.WM_ERASEBKGND:
                 {
                     RECT rect;


### PR DESCRIPTION
## Summary
- keep a rooted `SUBCLASSPROC` delegate per transparent window instead of a single process-wide slot
- remove the rooted delegate when the subclassed window is destroyed
- preserve the existing transparent-window behavior otherwise

## Why
`WindowUtilities.MakeTransparent()` currently stores the subclass callback in a single static field. Once another window is subclassed, the older callback can lose its managed root while the native subclass is still active. On .NET 10 that now terminates the process with a fail-fast when Windows invokes the collected delegate.

## Validation
- `dotnet build src/libs/H.NotifyIcon/H.NotifyIcon.csproj --configuration Release /p:GeneratePackageOnBuild=false`
- `dotnet build src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj --configuration Release /p:AppxGeneratePriEnabled=false /p:GeneratePackageOnBuild=false`

Fixes #229
