### PR TITLE
Add 'Enabled' property to PopupSubMenu

### DIFF
--- a/src/apps/H.NotifyIcon.Apps.Console/Program.cs
+++ b/src/apps/H.NotifyIcon.Apps.Console/Program.cs
@@ -35,6 +35,14 @@ trayIcon.ContextMenu = new PopupMenu
                     {
                         new PopupMenuItem("Item 2", (_, _) => ShowMessage(trayIcon, "Item 2")),
                     }
+                },
+                new PopupSubMenu("Disabled SubMenu")
+                {
+                    Enabled = false,
+                    Items =
+                    {
+                        new PopupMenuItem("You can't see me :)", (_, _) => {})
+                    }
                 }
             }
         },

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
@@ -75,6 +75,7 @@ public partial class TaskbarIcon
                         var item = new PopupSubMenu
                         {
                             Text = subItem.Text,
+                            Enabled = subItem.IsEnabled,
                         };
                         menuItems.Add(item);
 #if HAS_MAUI

--- a/src/libs/H.NotifyIcon/PopupMenus/PopupMenu.cs
+++ b/src/libs/H.NotifyIcon/PopupMenus/PopupMenu.cs
@@ -54,9 +54,14 @@ public class PopupMenu
             {
                 var subMenuHandle = PInvoke.CreatePopupMenu();
                 AppendToMenu(subMenuHandle, subMenu.Items);
+
+                var flags = MENU_ITEM_FLAGS.MF_POPUP;
+
+                if (!subMenu.Enabled) flags |= MENU_ITEM_FLAGS.MF_GRAYED;
+
                 return PInvoke.AppendMenu(
                     hMenu: handle,
-                    uFlags: MENU_ITEM_FLAGS.MF_POPUP,
+                    uFlags: flags,
                     uIDNewItem: (nuint)subMenuHandle.Value,
                     lpNewItem: subMenu.Text).EnsureNonZero();
             }

--- a/src/libs/H.NotifyIcon/PopupMenus/PopupSubMenu.cs
+++ b/src/libs/H.NotifyIcon/PopupMenus/PopupSubMenu.cs
@@ -14,6 +14,9 @@ public class PopupSubMenu : PopupItem
     }
 
     /// <inheritdoc/>
+    public bool Enabled { get; set; } = true;
+
+    /// <inheritdoc/>
     public string Text { get; set; } = string.Empty;
 
     /// <inheritdoc/>


### PR DESCRIPTION
This PR adds the boolean property `Enabled` to the `PopupSubMenu` which is used in Win32 PopupMenu.
This will allow us to disable a sub-menu just like we can disable `PopupMenuItem`.