### PR TITLE
fix: Preserve tray tooltip when showing notifications

### DIFF
--- a/src/libs/H.NotifyIcon/Core/TrayIcon.cs
+++ b/src/libs/H.NotifyIcon/Core/TrayIcon.cs
@@ -606,6 +606,10 @@ public partial class TrayIcon : IDisposable
         EnsureCreated();
 
         var additionalFlags = (NOTIFY_ICON_DATA_FLAGS)0;
+        if (UseStandardTooltip)
+        {
+            additionalFlags |= NOTIFY_ICON_DATA_FLAGS.NIF_SHOWTIP;
+        }
         if (realtime)
         {
             additionalFlags |= NOTIFY_ICON_DATA_FLAGS.NIF_REALTIME;
@@ -640,6 +644,7 @@ public partial class TrayIcon : IDisposable
         if (!TrayIconMethods.TryShowNotification(
             id: Id,
             additionalFlags: additionalFlags,
+            toolTip: ToolTip,
             title: title,
             message: message,
             infoFlags: infoFlags,

--- a/src/libs/H.NotifyIcon/Interop/TrayIconMethods.cs
+++ b/src/libs/H.NotifyIcon/Interop/TrayIconMethods.cs
@@ -268,6 +268,7 @@ internal static class TrayIconMethods
     public static unsafe bool TryShowNotification(
         Guid id,
         NOTIFY_ICON_DATA_FLAGS additionalFlags,
+        string toolTip,
         string title,
         string message,
         NOTIFY_ICON_INFOTIP_FLAGS infoFlags,
@@ -281,6 +282,7 @@ internal static class TrayIconMethods
                 cbSize = (uint)sizeof(NOTIFYICONDATAW64),
                 uFlags = additionalFlags |
                     NOTIFY_ICON_DATA_FLAGS.NIF_INFO |
+                    NOTIFY_ICON_DATA_FLAGS.NIF_TIP |
                     NOTIFY_ICON_DATA_FLAGS.NIF_GUID,
                 guidItem = id,
                 dwInfoFlags = (uint)infoFlags,
@@ -290,6 +292,7 @@ internal static class TrayIconMethods
                     uTimeout = timeoutInMilliseconds,
                 }
             };
+            toolTip.SetTo(&data.szTip._0, data.szTip.Length);
             message.SetTo(&data.szInfo._0, data.szInfo.Length);
             title.SetTo(&data.szInfoTitle._0, data.szInfoTitle.Length);
 
@@ -302,6 +305,7 @@ internal static class TrayIconMethods
                 cbSize = (uint)sizeof(NOTIFYICONDATAW32),
                 uFlags = additionalFlags |
                     NOTIFY_ICON_DATA_FLAGS.NIF_INFO |
+                    NOTIFY_ICON_DATA_FLAGS.NIF_TIP |
                     NOTIFY_ICON_DATA_FLAGS.NIF_GUID,
                 guidItem = id,
                 dwInfoFlags = (uint)infoFlags,
@@ -311,6 +315,7 @@ internal static class TrayIconMethods
                     uTimeout = timeoutInMilliseconds,
                 }
             };
+            toolTip.SetTo(&data.szTip._0, data.szTip.Length);
             message.SetTo(&data.szInfo._0, data.szInfo.Length);
             title.SetTo(&data.szInfoTitle._0, data.szInfoTitle.Length);
 


### PR DESCRIPTION
Fixes a regression where setting `ToolTipText` before `ForceCreate()` can be lost as the visible hover tooltip if `ShowNotification(...)` is called immediately after the tray icon is created.

## Repro

```csharp
_trayIcon = (TaskbarIcon)resources["TrayIcon"];
_trayIcon.ToolTipText = "Test";
_trayIcon.ForceCreate();
_trayIcon.ShowNotification("Test", "This stops the tooltip from showing");
```

Then try hovering the tray icon.

## Codex explanation

The tooltip is assigned before `ForceCreate()`, and `Create()` sends it to `Shell_NotifyIcon` with `NIF_TIP`. The problem is the immediately following notification update: `ShowNotification(...)` sends another `NIM_MODIFY` with `NIF_INFO`, but previously did not include the current tooltip fields. Explorer can then stop showing the hover tooltip until the tooltip is written again.

This change preserves the current tooltip state during the notification modify call by sending the cached tooltip text with `NIF_TIP`, and carrying `NIF_SHOWTIP` when `UseStandardTooltip` is enabled.
