### PR TITLE
feat: Add TrayLeftMouseClick routed event

### DIFF
--- a/src/apps/H.NotifyIcon.Apps.Wpf/Tutorials/07 - Events/EventVisualizerWindow.xaml
+++ b/src/apps/H.NotifyIcon.Apps.Wpf/Tutorials/07 - Events/EventVisualizerWindow.xaml
@@ -41,7 +41,7 @@
             </DoubleAnimationUsingKeyFrames>
         </Storyboard>
         <Storyboard
-            x:Key="ShowMouseUp"
+            x:Key="ShowLeftMouseClick"
             AutoReverse="True"
             >
             <DoubleAnimationUsingKeyFrames
@@ -115,12 +115,12 @@
             <BeginStoryboard Storyboard="{StaticResource ShowMovement}" />
         </EventTrigger>
         <EventTrigger
-            RoutedEvent="tb:TaskbarIcon.TrayLeftMouseUp"
+            RoutedEvent="tb:TaskbarIcon.TrayLeftMouseClick"
             SourceName="notifyIcon"
             >
             <BeginStoryboard
-                Storyboard="{StaticResource ShowMouseUp}"
-                x:Name="ShowMouseUp_BeginStoryboard"
+                Storyboard="{StaticResource ShowLeftMouseClick}"
+                x:Name="ShowLeftMouseClick_BeginStoryboard"
                 />
         </EventTrigger>
         <EventTrigger
@@ -237,7 +237,7 @@
             >
             <Run
                 Language="de-ch"
-                Text="TrayLeftMouseUp Event"
+                Text="TrayLeftMouseClick Event"
                 />
         </TextBlock>
         <TextBlock

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.MouseEvents.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.MouseEvents.cs
@@ -12,6 +12,8 @@
     Description = "Occurs when the user releases the right mouse button.", Category = CategoryName)]
 [RoutedEvent("TrayMiddleMouseUp", RoutedEventStrategy.Bubble,
     Description = "Occurs when the user releases the middle mouse button.", Category = CategoryName)]
+[RoutedEvent("TrayLeftMouseClick", RoutedEventStrategy.Bubble,
+    Description = "Occurs when the user clicks the left mouse button without completing a double click.", Category = CategoryName)]
 [RoutedEvent("TrayLeftMouseDoubleClick", RoutedEventStrategy.Bubble,
     Description = "Occurs when the left mouse button was double clicked.", Category = CategoryName)]
 [RoutedEvent("TrayRightMouseDoubleClick", RoutedEventStrategy.Bubble,
@@ -145,6 +147,7 @@ public partial class TaskbarIcon
                 // show popup once we are sure it's not a double click
                 SingleClickTimerAction = () =>
                 {
+                    _ = OnTrayLeftMouseClick();
 #if HAS_WPF
                     LeftClickCommand?.TryExecute(LeftClickCommandParameter, LeftClickCommandTarget ?? this);
 #else
@@ -171,6 +174,7 @@ public partial class TaskbarIcon
                 // show context menu once we are sure it's not a double click
                 SingleClickTimerAction = () =>
                 {
+                    _ = OnTrayLeftMouseClick();
 #if HAS_WPF
                     LeftClickCommand?.TryExecute(LeftClickCommandParameter, LeftClickCommandTarget ?? this);
 #else
@@ -194,6 +198,7 @@ public partial class TaskbarIcon
             // show context menu once we are sure it's not a double click
             SingleClickTimerAction = () =>
             {
+                _ = OnTrayLeftMouseClick();
 #if HAS_WPF
                 LeftClickCommand?.TryExecute(LeftClickCommandParameter, LeftClickCommandTarget ?? this);
 #else

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.MouseEvents.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.MouseEvents.cs
@@ -12,8 +12,10 @@
     Description = "Occurs when the user releases the right mouse button.", Category = CategoryName)]
 [RoutedEvent("TrayMiddleMouseUp", RoutedEventStrategy.Bubble,
     Description = "Occurs when the user releases the middle mouse button.", Category = CategoryName)]
+#if !HAS_MAUI
 [RoutedEvent("TrayLeftMouseClick", RoutedEventStrategy.Bubble,
     Description = "Occurs when the user clicks the left mouse button without completing a double click.", Category = CategoryName)]
+#endif
 [RoutedEvent("TrayLeftMouseDoubleClick", RoutedEventStrategy.Bubble,
     Description = "Occurs when the left mouse button was double clicked.", Category = CategoryName)]
 [RoutedEvent("TrayRightMouseDoubleClick", RoutedEventStrategy.Bubble,
@@ -147,7 +149,9 @@ public partial class TaskbarIcon
                 // show popup once we are sure it's not a double click
                 SingleClickTimerAction = () =>
                 {
+#if !HAS_MAUI
                     _ = OnTrayLeftMouseClick();
+#endif
 #if HAS_WPF
                     LeftClickCommand?.TryExecute(LeftClickCommandParameter, LeftClickCommandTarget ?? this);
 #else
@@ -174,7 +178,9 @@ public partial class TaskbarIcon
                 // show context menu once we are sure it's not a double click
                 SingleClickTimerAction = () =>
                 {
+#if !HAS_MAUI
                     _ = OnTrayLeftMouseClick();
+#endif
 #if HAS_WPF
                     LeftClickCommand?.TryExecute(LeftClickCommandParameter, LeftClickCommandTarget ?? this);
 #else
@@ -198,7 +204,9 @@ public partial class TaskbarIcon
             // show context menu once we are sure it's not a double click
             SingleClickTimerAction = () =>
             {
+#if !HAS_MAUI
                 _ = OnTrayLeftMouseClick();
+#endif
 #if HAS_WPF
                 LeftClickCommand?.TryExecute(LeftClickCommandParameter, LeftClickCommandTarget ?? this);
 #else


### PR DESCRIPTION
Adds a `TrayLeftMouseClick` routed event for `TaskbarIcon`.

When an app handles both `TrayLeftMouseDown` and `TrayLeftMouseDoubleClick`, the mouse-down handler can still run as part of a double-click sequence. `LeftClickCommand` already avoids that by using the existing delayed single-click path and cancelling it when a double-click is detected.

This event is raised from the same confirmed single-click path used by `LeftClickCommand`, so WPF event-based consumers can handle a left-click without also running that logic during a double-click sequence.
