### PR TITLE
Fix SUBCLASSPROC delegate lifetime

### DIFF
--- a/src/libs/H.NotifyIcon/Core/WindowUtilities.cs
+++ b/src/libs/H.NotifyIcon/Core/WindowUtilities.cs
@@ -1,4 +1,5 @@
 ﻿using H.NotifyIcon.Interop;
+using System.Collections.Concurrent;
 
 namespace H.NotifyIcon.Core;
 
@@ -137,13 +138,14 @@ public static class WindowUtilities
     {
         var hWnd = new HWND(hWndHandle);
 
-        SubClassDelegate = new SUBCLASSPROC(WindowSubClass);
+        var subClassDelegate = new SUBCLASSPROC(WindowSubClass);
 
         _ = PInvoke.SetWindowSubclass(
             hWnd: hWnd,
-            pfnSubclass: SubClassDelegate,
+            pfnSubclass: subClassDelegate,
             uIdSubclass: 0,
             dwRefData: 0).EnsureNonZero();
+        SubClassDelegates[hWndHandle] = subClassDelegate;
 
         var exStyle = (WINDOW_EX_STYLE)User32Methods.GetWindowLong(
             hWnd: hWnd,
@@ -162,7 +164,7 @@ public static class WindowUtilities
     
     private static int ToWin32(System.Drawing.Color c) => (int) c.B << 16 | (int) c.G << 8 | (int) c.R;
     
-    private static SUBCLASSPROC? SubClassDelegate;
+    private static readonly ConcurrentDictionary<nint, SUBCLASSPROC> SubClassDelegates = new();
 
     [SupportedOSPlatform("windows5.1.2600")]
     private static unsafe LRESULT WindowSubClass(HWND hWnd, uint uMsg, WPARAM wParam, LPARAM lParam, nuint uIdSubclass, nuint dwRefData)
@@ -185,6 +187,18 @@ public static class WindowUtilities
                         ho: hBrush).EnsureNonZero();
 
                     return new LRESULT(1);
+                }
+            case PInvoke.WM_NCDESTROY:
+                {
+                    if (SubClassDelegates.TryRemove((nint)hWnd.Value, out var subClassDelegate))
+                    {
+                        _ = PInvoke.RemoveWindowSubclass(
+                            hWnd: hWnd,
+                            pfnSubclass: subClassDelegate,
+                            uIdSubclass: uIdSubclass);
+                    }
+
+                    break;
                 }
         }
 

--- a/src/libs/H.NotifyIcon/NativeMethods.txt
+++ b/src/libs/H.NotifyIcon/NativeMethods.txt
@@ -12,12 +12,14 @@ GetWindowLong
 SetWindowPos
 DefSubclassProc
 SetWindowSubclass
+RemoveWindowSubclass
 GetClientRect
 FillRect
 CreateSolidBrush
 DeleteObject
 SetLayeredWindowAttributes
 WM_ERASEBKGND
+WM_NCDESTROY
 GetDoubleClickTime
 GetPhysicalCursorPos
 GetCursorPos


### PR DESCRIPTION
## Summary

Fixes the native subclass callback lifetime issue reported in #229.

## Root cause

`WindowUtilities.MakeTransparent` stored each `SUBCLASSPROC` callback in a single static field. If multiple windows were subclassed, later calls could replace the only managed reference while older native subclass registrations still held their original function pointers. On .NET 10, invoking a collected delegate from native code can FailFast instead of failing silently.

## Changes

- Store subclass delegates per HWND in a static `ConcurrentDictionary`.
- Remove the per-window delegate root when the subclass receives `WM_NCDESTROY`.
- Add `RemoveWindowSubclass` and `WM_NCDESTROY` to the CsWin32 input list.

## Validation

- `dotnet build H.NotifyIcon.PR.slnx --configuration Release`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=normal"`

Both passed locally for this branch. This remains a draft until the broader local verification pass is complete.