### PR TITLE
Fix PNG IconSource conversion

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/Utilities/System.Drawing/StreamExtensions.cs
+++ b/src/libs/H.NotifyIcon.Shared/Utilities/System.Drawing/StreamExtensions.cs
@@ -8,8 +8,16 @@ internal static class StreamExtensions
     internal static Icon ToSmallIcon(this Stream stream)
     {
         var iconSize = IconUtilities.GetRequiredCustomIconSize(largeIcon: false).ScaleWithDpi();
+        var data = stream.ToArray();
 
-        return new Icon(stream, iconSize);
+        if (IsPng(data))
+        {
+            data = data.ConvertPngToIco();
+        }
+
+        using var iconStream = new MemoryStream(data);
+
+        return new Icon(iconStream, iconSize);
     }
     
     [SupportedOSPlatform("windows")]
@@ -24,5 +32,31 @@ internal static class StreamExtensions
         using var image = System.Drawing.Image.FromStream(stream);
         
         return (image.Width, image.Height, System.Drawing.Image.GetPixelFormatSize(image.PixelFormat));
+    }
+
+    private static byte[] ToArray(this Stream stream)
+    {
+        if (stream is MemoryStream memoryStream)
+        {
+            return memoryStream.ToArray();
+        }
+
+        using var copy = new MemoryStream();
+        stream.CopyTo(copy);
+
+        return copy.ToArray();
+    }
+
+    private static bool IsPng(byte[] data)
+    {
+        return data.Length >= 8 &&
+               data[0] == 0x89 &&
+               data[1] == 0x50 &&
+               data[2] == 0x4E &&
+               data[3] == 0x47 &&
+               data[4] == 0x0D &&
+               data[5] == 0x0A &&
+               data[6] == 0x1A &&
+               data[7] == 0x0A;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #208 by allowing PNG-backed `IconSource` streams to be converted into Windows icons through the System.Drawing backend.

## Root cause

`IconSource` uses the async image conversion path. For non-generated image sources, that path produced a raw PNG stream and passed it directly to `new Icon(...)`, which expects ICO data and throws `ArgumentException` for PNG resources.

## Changes

- Read image stream bytes before constructing the small icon.
- Detect PNG input by signature.
- Convert PNG bytes to ICO bytes with the existing `ConvertPngToIco` helper before calling `new Icon(...)`.
- Preserve existing behavior for ICO streams and other icon-compatible streams.

## Validation

- `dotnet build H.NotifyIcon.PR.slnx --configuration Release`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=normal"`

Both passed locally for this branch. The existing integration test suite does not directly cover WPF `IconSource` PNG conversion, so this remains a draft until we add or run a focused repro validation.