### PR TITLE
Fix process path fallback for tray icon IDs

### DIFF
--- a/src/libs/H.NotifyIcon/Core/TrayIcon.cs
+++ b/src/libs/H.NotifyIcon/Core/TrayIcon.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using EventGenerator;
 #if MACOS
@@ -227,19 +228,25 @@ public partial class TrayIcon : IDisposable
             return processPath;
         }
 #endif
-        using (var process = Process.GetCurrentProcess())
+        try
         {
-            var path = process?.MainModule?.FileName;
+            using var process = Process.GetCurrentProcess();
+            var path = process.MainModule?.FileName;
             if (path != null &&
                 !string.IsNullOrWhiteSpace(path))
             {
                 return path;
             }
         }
+        catch (Exception exception) when (exception is Win32Exception or InvalidOperationException or NotSupportedException)
+        {
+            // Some endpoint protection tools can block MainModule access.
+            // Fall back to managed application paths instead of failing construction.
+        }
         
         var assembly =
             Assembly.GetEntryAssembly() ??
-            throw new InvalidOperationException("Entry assembly is not found.");
+            Assembly.GetExecutingAssembly();
 
         var location = assembly.Location;
         if (string.IsNullOrWhiteSpace(location))


### PR DESCRIPTION
## Summary

Fixes #188 by preventing default `TrayIcon` construction from failing when `Process.MainModule` access is blocked.

## Root cause

The default tray icon ID is derived from the current process path. On affected machines, endpoint or memory-protection software can make `Process.GetCurrentProcess().MainModule.FileName` throw, which currently aborts `TrayIcon` / `TaskbarIcon` construction before users can set a custom ID/name.

## Changes

- Keep the existing `Environment.ProcessPath` fast path for modern .NET targets.
- Catch expected process module lookup failures from `MainModule`.
- Fall back to managed assembly location, then `AppContext.BaseDirectory`, instead of throwing during construction.

## Validation

- `dotnet build H.NotifyIcon.PR.slnx --configuration Release`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=normal"`

Both passed locally for this branch. This remains a draft until the broader local verification pass is complete.