### PR TITLE
Guard MAUI tray creation on non-Windows

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
@@ -53,6 +53,7 @@ public partial class TaskbarIcon : FrameworkElement
 
         TrayIcon = new TrayIcon();
         Id = TrayIcon.Id;
+#if !HAS_MAUI || HAS_MAUI_WINUI
         Loaded += (_, _) =>
         {
             try
@@ -64,8 +65,9 @@ public partial class TaskbarIcon : FrameworkElement
                 Debugger.Break();
             }
         };
+#endif
         
-#if !MACOS
+#if !MACOS && (!HAS_MAUI || HAS_MAUI_WINUI)
         // https://github.com/HavenDV/H.NotifyIcon/issues/34
         //Unloaded += (_, _) => Dispose();
         TrayIcon.MessageWindow.DpiChanged += static (_, _) => DpiUtilities.UpdateDpiFactors();
@@ -129,6 +131,9 @@ public partial class TaskbarIcon : FrameworkElement
     [SupportedOSPlatform("windows5.1.2600")]
     public void ForceCreate(bool enablesEfficiencyMode = true)
     {
+#if HAS_MAUI && !HAS_MAUI_WINUI
+        return;
+#else
         TrayIcon.Create();
 
         if (enablesEfficiencyMode &&
@@ -144,6 +149,7 @@ public partial class TaskbarIcon : FrameworkElement
         // This seems to have been fixed in Windows 22598.1 but I'll leave it here for now
         //using var refreshTrayIcon = new TrayIcon(TrayIcon.CreateUniqueGuidForEntryAssembly("RefreshWorkaround"));
         //refreshTrayIcon.Create();
+#endif
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Addresses #204 by preventing MAUI non-Windows targets from automatically creating the Windows tray backend.

## Root cause

`H.NotifyIcon.Maui` targets Android, iOS, Mac Catalyst, and Windows, but the shared `TaskbarIcon` constructor auto-created the tray icon on load for all MAUI targets. On Mac Catalyst this could reach the Windows `MessageWindow`/USER32 path and throw `DllNotFoundException: USER32.dll`.

## Changes

- Only auto-create the tray icon from `Loaded` for non-MAUI platforms or MAUI WinUI.
- Make `ForceCreate` a no-op for MAUI non-Windows targets.
- Leave Windows MAUI behavior unchanged.

This does not add a native macOS tray implementation; it prevents the Windows backend from crashing non-Windows MAUI apps.

## Validation

- `dotnet build src\libs\H.NotifyIcon.Maui\H.NotifyIcon.Maui.csproj --configuration Release`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --logger "console;verbosity=normal"`

All passed locally. This remains a draft until broader local verification is complete.