### PR TITLE
Fix MAUI tray click commands

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.MouseEvents.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.MouseEvents.cs
@@ -135,6 +135,20 @@ public partial class TaskbarIcon
                 throw new ArgumentOutOfRangeException(nameof(args), "Missing handler for mouse event flag: " + args.MouseEvent);
         }
 #endif
+#elif HAS_MAUI_WINUI
+        switch (args.MouseEvent)
+        {
+            case MouseEvent.IconRightMouseUp:
+                RightClickCommand?.TryExecute(RightClickCommandParameter);
+                break;
+            case MouseEvent.IconMiddleMouseUp:
+                MiddleClickCommand?.TryExecute(MiddleClickCommandParameter);
+                break;
+            case MouseEvent.IconDoubleClick:
+                SingleClickTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                DoubleClickCommand?.TryExecute(DoubleClickCommandParameter);
+                break;
+        }
 #endif
 
         var cursorPosition = args.Point.ScaleWithDpi();


### PR DESCRIPTION
## What changed

Adds a MAUI Windows mouse-event command dispatch path for tray icon right-click, middle-click, and double-click commands.

## Why

The existing mouse-event switch was compiled out for MAUI. Left-click commands still ran through the later left-click timer path, but `RightClickCommand`, `MiddleClickCommand`, and `DoubleClickCommand` never executed for MAUI Windows.

Fixes #210.
Fixes #101.

## Validation

- `dotnet build src\libs\H.NotifyIcon.Maui\H.NotifyIcon.Maui.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.Maui\H.NotifyIcon.Apps.Maui.csproj --configuration Release -f net10.0-windows10.0.19041.0 --nologo`