### PR TITLE
[codex] Add context menu close API

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
@@ -64,6 +64,39 @@ public partial class TaskbarIcon
 #endif
     }
 
+    /// <summary>
+    /// Hides the ContextMenu/ContextFlyout if it is visible.
+    /// </summary>
+    [SupportedOSPlatform("windows5.1.2600")]
+    public void CloseContextMenu()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        switch (ContextMenuMode)
+        {
+#if !HAS_MAUI
+#if !HAS_UNO
+            case ContextMenuMode.SecondWindow:
+                CloseSecondWindowContextMenu();
+                break;
+#endif
+
+            case ContextMenuMode.ActiveWindow:
+#endif
+            case ContextMenuMode.PopupMenu:
+#if !HAS_MAUI
+                ContextFlyout?.Hide();
+#endif
+                break;
+
+            default:
+                throw new NotImplementedException($"ContextMenuMode: {ContextMenuMode} is not implemented.");
+        }
+    }
+
     #endregion
 
     #region Event Handlers

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -83,6 +83,18 @@ public partial class TaskbarIcon
         ShowSecondWindowFlyout(ContextMenuFlyout, ContextMenuWindow.Content);
     }
 
+    private void CloseSecondWindowContextMenu()
+    {
+        IsContextMenuVisible = false;
+        IsSecondWindowContextMenuOpenEventRaised = false;
+        ContextMenuFlyout?.Hide();
+
+        if (ContextMenuWindowHandle is { } handle)
+        {
+            _ = WindowUtilities.HideWindow(handle);
+        }
+    }
+
     private static System.Drawing.Rectangle CreateTrayCursorExcludeRect(
         System.Drawing.Point cursorPosition,
         double rasterizationScale)
@@ -209,10 +221,7 @@ public partial class TaskbarIcon
             {
                 flyoutItemBase.Tapped += (_, _) =>
                 {
-                    IsContextMenuVisible = false;
-                    IsSecondWindowContextMenuOpenEventRaised = false;
-                    flyout.Hide();
-                    _ = WindowUtilities.HideWindow(handle);
+                    CloseSecondWindowContextMenu();
                 };
             }
         }
@@ -235,10 +244,7 @@ public partial class TaskbarIcon
         {
             if (args.WindowActivationState == WindowActivationState.Deactivated)
             {
-                IsContextMenuVisible = false;
-                IsSecondWindowContextMenuOpenEventRaised = false;
-                flyout.Hide();
-                _ = WindowUtilities.HideWindow(handle);
+                CloseSecondWindowContextMenu();
                 return;
             }
 

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.Wpf.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.Wpf.cs
@@ -58,6 +58,24 @@ public partial class TaskbarIcon
         _ = OnTrayContextMenuOpen();
     }
 
+    /// <summary>
+    /// Hides the ContextMenu/ContextFlyout if it is visible.
+    /// </summary>
+    public void CloseContextMenu()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        if (ContextMenu == null)
+        {
+            return;
+        }
+
+        ContextMenu.IsOpen = false;
+    }
+
     #endregion
 
     #region Event Handlers


### PR DESCRIPTION
## Summary
- add `TaskbarIcon.CloseContextMenu()` for WinRT/WinUI and WPF wrappers
- close the internal SecondWindow `MenuFlyout` and hide its transparent host window through one helper
- keep MAUI PopupMenu close as a no-op because there is no live XAML flyout in that mode

Fixes #144.

## Validation
- `dotnet build src\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj --configuration Release --nologo`
- `dotnet build src\libs\H.NotifyIcon.Wpf\H.NotifyIcon.Wpf.csproj --configuration Release --nologo`
- `dotnet build src\libs\H.NotifyIcon.Maui\H.NotifyIcon.Maui.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj --configuration Release -p:Platform=x64 -p:WindowsPackageType=None --nologo`
- Computer Use smoke test: launched the built WinUI sample, verified the `WinUI Desktop` window rendered, then closed it cleanly
