### PR TITLE
[codex] Add option to keep SecondWindow context menus open

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
@@ -4,6 +4,8 @@ namespace H.NotifyIcon;
 
 [DependencyProperty<ContextMenuMode>("ContextMenuMode", DefaultValue = ContextMenuMode.PopupMenu,
     Description = "Defines the context menu mode.", Category = CategoryName)]
+[DependencyProperty<bool>("CloseContextMenuOnItemClick", DefaultValue = true,
+    Description = "Defines whether the second-window context menu closes after a menu item is clicked.", Category = CategoryName)]
 public partial class TaskbarIcon
 {
     #region Methods

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -193,6 +193,14 @@ public partial class TaskbarIcon
                 _ = OnSecondWindowContextMenuOpened();
             }
         };
+        flyout.Closing += (_, args) =>
+        {
+            if (!CloseContextMenuOnItemClick &&
+                IsContextMenuVisible)
+            {
+                args.Cancel = true;
+            }
+        };
         flyout.Closed += (_, _) =>
         {
             if (!flyout.AreOpenCloseAnimationsEnabled ||
@@ -221,7 +229,10 @@ public partial class TaskbarIcon
             {
                 flyoutItemBase.Tapped += (_, _) =>
                 {
-                    CloseSecondWindowContextMenu();
+                    if (CloseContextMenuOnItemClick)
+                    {
+                        CloseSecondWindowContextMenu();
+                    }
                 };
             }
         }


### PR DESCRIPTION
## Summary
- add `TaskbarIcon.CloseContextMenuOnItemClick` with the current behavior preserved by default
- when `CloseContextMenuOnItemClick="False"` and `ContextMenuMode="SecondWindow"`, cancel the internal flyout close so item clicks can leave the menu open
- keep library-initiated close paths intact, including light-dismiss/deactivation and `CloseContextMenu()`

Fixes #206.

## Validation
- `dotnet build src\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj --configuration Release --nologo`
- `dotnet build src\libs\H.NotifyIcon.Maui\H.NotifyIcon.Maui.csproj --configuration Release --nologo`
- `dotnet build src\libs\H.NotifyIcon.Uno.WinUI\H.NotifyIcon.Uno.WinUI.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj --configuration Release -p:Platform=x64 -p:WindowsPackageType=None --nologo`
- Computer Use smoke test: launched the built WinUI sample, verified the `WinUI Desktop` window rendered, then closed it cleanly

Note: the first parallel WinUI/MAUI build attempt hit a local output file lock from concurrent builds; both builds passed when rerun sequentially.
