### PR TITLE
[codex] Close SecondWindow context menu before dispose

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
@@ -125,6 +125,7 @@ public partial class TaskbarIcon : IDisposable
 #endif
 
 #if !HAS_WPF && !HAS_UNO && !HAS_MAUI
+            CloseSecondWindowContextMenu();
             ContextMenuWindow?.Close();
             ContextMenuWindow = null;
             ContextMenuWindowHandle = null;


### PR DESCRIPTION
## What changed
- Close the live SecondWindow context menu before closing the WinUI context menu host window during `TaskbarIcon.Dispose()`.

## Why
The SecondWindow flyout `Closed` handler can reopen the flyout while `IsContextMenuVisible` is still true. If disposal closes the WinUI host window first, that handler can read `window.Content` after the WinUI Desktop Window has already been closed, matching the COMException reported in #175.

Fixes #175.

## Validation
- `dotnet build src\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj --configuration Release --nologo`
- `dotnet build src\libs\H.NotifyIcon.Maui\H.NotifyIcon.Maui.csproj --configuration Release --nologo`
- `dotnet build src\libs\H.NotifyIcon.Wpf\H.NotifyIcon.Wpf.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj --configuration Release -p:Platform=x64 -p:WindowsPackageType=None --nologo`
- Computer Use smoke: launched the built WinUI sample, verified the `WinUI Desktop` window rendered, then closed the main window.

Note: the sample keeps a tray-only process alive when the main window closes, so I stopped that sample process after the smoke test to release build output locks.
