### PR TITLE
[codex] Add native context menu opening event

### DIFF
--- a/src/libs/H.NotifyIcon/PopupMenus/TrayIconWithContextMenu.cs
+++ b/src/libs/H.NotifyIcon/PopupMenus/TrayIconWithContextMenu.cs
@@ -1,11 +1,14 @@
 ﻿#if !MACOS
 using System.Drawing;
 using System.Threading;
+using EventGenerator;
 using H.NotifyIcon.Interop;
 
 namespace H.NotifyIcon.Core;
 
 /// <inheritdoc/>
+[Event("ContextMenuOpening",
+    Description = "Occurs before the context menu is displayed.")]
 [SupportedOSPlatform("windows5.1.2600")]
 public partial class TrayIconWithContextMenu : TrayIcon
 {
@@ -99,10 +102,17 @@ public partial class TrayIconWithContextMenu : TrayIcon
     /// </summary>
     public void ShowContextMenu()
     {
+        _ = OnContextMenuOpening();
+
+        if (ContextMenu == null)
+        {
+            return;
+        }
+
         var cursorPosition = CursorUtilities.GetCursorPos();
 
         _ = WindowUtilities.SetForegroundWindow(WindowHandle);
-        ContextMenu?.Show(
+        ContextMenu.Show(
             ownerHandle: WindowHandle,
             x: cursorPosition.X,
             y: cursorPosition.Y);

--- a/src/tests/H.NotifyIcon.IntegrationTests/TrayIconTests.cs
+++ b/src/tests/H.NotifyIcon.IntegrationTests/TrayIconTests.cs
@@ -7,6 +7,18 @@ namespace H.NotifyIcon.IntegrationTests;
 public class TrayIconTests
 {
     [TestMethod]
+    public void ContextMenuOpeningIsRaisedWithoutContextMenu()
+    {
+        using var trayIcon = new TrayIconWithContextMenu();
+        var wasRaised = false;
+
+        trayIcon.ContextMenuOpening += (_, _) => wasRaised = true;
+        trayIcon.ShowContextMenu();
+
+        wasRaised.Should().BeTrue();
+    }
+
+    [TestMethod]
     public async Task SimpleTest()
     {
         using var trayIcon = new TrayIcon();


### PR DESCRIPTION
## What changed
- Added `TrayIconWithContextMenu.ContextMenuOpening`, raised at the start of `ShowContextMenu()` before `ContextMenu` is read.
- Added an integration test proving the event fires even when no context menu is currently assigned.

## Why
`MessageWindow.InitMenuPopup` is tied to the low-level Win32 message and was not a reliable/ergonomic API for updating native menu state before opening. The new event gives core `TrayIconWithContextMenu` users a direct hook to enable/disable items or assign the menu lazily before display.

Fixes #105.

## Validation
- `dotnet build src\libs\H.NotifyIcon\H.NotifyIcon.csproj --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --nologo --logger "console;verbosity=minimal"`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
