### PR TITLE
[codex] Make generated WPF icons DPI aware

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/GeneratedIconSource.System.Drawing.cs
+++ b/src/libs/H.NotifyIcon.Shared/GeneratedIconSource.System.Drawing.cs
@@ -29,7 +29,10 @@ public sealed partial class GeneratedIconSource
     [SupportedOSPlatform("windows")]
     internal Bitmap Generate(Bitmap? backgroundBitmap = null)
     {
-        var size = Size;
+        var size = Size.ScaleToDpiPixels();
+        var margin = Margin.ScaleToDpiPixels();
+        var textMargin = TextMargin.ScaleToDpiPixels();
+        var borderThickness = BorderThickness.ScaleToDpiPixels();
         using var fontFamily =
             FontFamily?.ToSystemDrawingFontFamily() ??
             new System.Drawing.FontFamily(string.Empty);
@@ -38,24 +41,24 @@ public sealed partial class GeneratedIconSource
             (float)FontSize,
             FontStyle.ToSystemDrawingFontStyle(FontWeight));
         using var baseImage = backgroundBitmap ?? BackgroundSource?.ToBitmap();
-        using var pen = BorderBrush.ToSystemDrawingPen(BorderThickness);
+        using var pen = BorderBrush.ToSystemDrawingPen(borderThickness);
         using var backgroundBrush = Background.ToSystemDrawingBrush();
         using var foregroundBrush = Foreground.ToSystemDrawingBrush();
 
         return SystemDrawingIconGenerator.Generate(
             backgroundBrush: backgroundBrush,
             foregroundBrush: foregroundBrush,
-            pen: BorderThickness > 0.01F
+            pen: borderThickness > 0.01F
                 ? pen
                 : null,
             backgroundType: BackgroundType,
-            cornerRadius: (float)CornerRadius.TopLeft,
+            cornerRadius: (float)CornerRadius.TopLeft.ScaleToDpiPixels(),
             rectangle: Margin == default
                 ? null
-                : Margin.ToSystemDrawingRectangleF(width: size, height: size),
+                : margin.ToSystemDrawingRectangleF(width: size, height: size),
             text: Text,
             font: font,
-            textRectangle: TextMargin.ToSystemDrawingRectangleF(width: size, height: size),
+            textRectangle: textMargin.ToSystemDrawingRectangleF(width: size, height: size),
             baseImage: baseImage,
             size: size);
     }

--- a/src/libs/H.NotifyIcon.Shared/GeneratedIconSource.Wpf.System.Drawing.cs
+++ b/src/libs/H.NotifyIcon.Shared/GeneratedIconSource.Wpf.System.Drawing.cs
@@ -24,8 +24,8 @@ public sealed partial class GeneratedIconSource
         return Create(
             pixelWidth: bitmap.Width,
             pixelHeight: bitmap.Height,
-            dpiX: 96,
-            dpiY: 96,
+            dpiX: 96 * DpiUtilities.DpiFactorX,
+            dpiY: 96 * DpiUtilities.DpiFactorY,
             pixelFormat: PixelFormats.Rgb24,
             palette: null,
             buffer: bits.Scan0,

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.cs
@@ -70,7 +70,7 @@ public partial class TaskbarIcon : FrameworkElement
 #if !MACOS && (!HAS_MAUI || HAS_MAUI_WINUI)
         // https://github.com/HavenDV/H.NotifyIcon/issues/34
         //Unloaded += (_, _) => Dispose();
-        TrayIcon.MessageWindow.DpiChanged += static (_, _) => DpiUtilities.UpdateDpiFactors();
+        TrayIcon.MessageWindow.DpiChanged += OnDpiChanged;
         TrayIcon.MessageWindow.TaskbarCreated += OnTaskbarCreated;
 
         // register event listeners
@@ -118,6 +118,22 @@ public partial class TaskbarIcon : FrameworkElement
         {
             // ignored.
         }
+    }
+
+    /// <summary>
+    /// Refreshes the tray icon after Windows reports a DPI change.
+    /// </summary>
+    [SupportedOSPlatform("windows5.1.2600")]
+    private async void OnDpiChanged(object? sender, EventArgs args)
+    {
+        DpiUtilities.UpdateDpiFactors();
+
+        if (IconSource == null)
+        {
+            return;
+        }
+
+        Icon = await IconSource.ToIconAsync().ConfigureAwait(true);
     }
 
     #endregion

--- a/src/libs/H.NotifyIcon.Shared/Utilities/DpiUtilities.cs
+++ b/src/libs/H.NotifyIcon.Shared/Utilities/DpiUtilities.cs
@@ -44,4 +44,30 @@ internal static class DpiUtilities
             Height = (int)(size.Height / DpiFactorY),
         };
     }
+
+    internal static int ScaleToDpiPixels(this int value)
+    {
+        return Math.Max(
+            val1: 1,
+            val2: (int)Math.Round(value * Math.Max(DpiFactorX, DpiFactorY)));
+    }
+
+    internal static float ScaleToDpiPixels(this float value)
+    {
+        return (float)(value * Math.Max(DpiFactorX, DpiFactorY));
+    }
+
+    internal static double ScaleToDpiPixels(this double value)
+    {
+        return value * Math.Max(DpiFactorX, DpiFactorY);
+    }
+
+    internal static Thickness ScaleToDpiPixels(this Thickness thickness)
+    {
+        return new Thickness(
+            left: thickness.Left * DpiFactorX,
+            top: thickness.Top * DpiFactorY,
+            right: thickness.Right * DpiFactorX,
+            bottom: thickness.Bottom * DpiFactorY);
+    }
 }


### PR DESCRIPTION
## Summary
- scale WPF `GeneratedIconSource.Size` into device pixels before rendering the System.Drawing backing bitmap
- scale generated icon margins, text margins, border thickness, and corner radius into the same bitmap coordinate space
- preserve WPF logical sizing by setting generated bitmap DPI metadata and refresh `IconSource` when Windows reports a DPI change

Closes #182.

## Local validation
- `dotnet build src\libs\H.NotifyIcon.Wpf\H.NotifyIcon.Wpf.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.Wpf\H.NotifyIcon.Apps.Wpf.csproj --configuration Release --nologo`
- Computer Use smoke: launched the WPF sample, opened the Context Menus tutorial that creates a `GeneratedIconSource` tray icon, and verified the window rendered without a tray icon generation exception.
- Reflection probe: forced `DpiUtilities` to 2.0 in the `net4.6.2` WPF build and verified `GeneratedIconSource.Size = 16` produced a `32x32` bitmap.

## Note
- `dotnet build src\libs\H.NotifyIcon.Wpf\H.NotifyIcon.Wpf.csproj --configuration Release -p:GraphicsLibrary=SkiaSharp --nologo` currently fails before this change is reached because the WPF wrapper does not reference SkiaSharp when that property is forced locally. I kept this PR scoped to the default System.Drawing path that is covered by the PR solution build.