### PR TITLE
[codex] Disable standard shell tooltip for custom tray tooltips

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ToolTips.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ToolTips.cs
@@ -38,6 +38,7 @@ public partial class TaskbarIcon
     partial void OnTrayToolTipChanged(UIElement? oldValue, UIElement? newValue)
     {
         CreateCustomToolTip();
+        UpdateStandardToolTipMode();
 
 #if HAS_WPF
         if (oldValue != null)
@@ -110,9 +111,14 @@ public partial class TaskbarIcon
     private void CreateCustomToolTip()
     {
 #if !MACOS && !HAS_MAUI
+        if (TrayToolTip == null)
+        {
+            TrayToolTipResolved = null;
+            return;
+        }
+
         var toolTip = TrayToolTip as ToolTip2 ?? new ToolTip2();
-        if (TrayToolTip != null &&
-            TrayToolTip is not ToolTip2)
+        if (TrayToolTip is not ToolTip2)
         {
             toolTip.Content = TrayToolTip;
         }
@@ -123,9 +129,18 @@ public partial class TaskbarIcon
 #endif
     }
 
+    private void UpdateStandardToolTipMode()
+    {
+#if HAS_WPF || HAS_WINUI || HAS_UNO_WINUI || HAS_MAUI_WINUI
+        TrayIcon.UseStandardTooltip = TrayToolTipResolved == null;
+#endif
+    }
+
     [SupportedOSPlatform("windows5.1.2600")]
     private void WriteToolTipSettings()
     {
+        UpdateStandardToolTipMode();
+
         var text = ToolTipText;
 #if !MACOS
         if (TrayIcon.Version == IconVersion.Vista)


### PR DESCRIPTION
## Summary
- clear `TrayToolTipResolved` when `TrayToolTip` is removed so the control can return to plain `ToolTipText`
- disable the native standard shell tooltip whenever a custom tray tooltip is configured
- keep standard tooltip mode enabled when no custom tooltip is present

Closes #43.

## Local validation
- `dotnet build src\libs\H.NotifyIcon.Wpf\H.NotifyIcon.Wpf.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.Wpf\H.NotifyIcon.Apps.Wpf.csproj --configuration Release --nologo`
- Computer Use smoke: launched the WPF sample and opened the inline tooltip tutorial that creates a custom `TrayToolTip`.
- Reflection probe: verified `TrayIcon.UseStandardTooltip` becomes `False` when `TrayToolTip` is set and returns to `True` after `TrayToolTip` is cleared.