### PR TITLE
[codex] Resize generated HICONs to tray icon size

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/GeneratedIconSource.System.Drawing.cs
+++ b/src/libs/H.NotifyIcon.Shared/GeneratedIconSource.System.Drawing.cs
@@ -6,10 +6,10 @@ public sealed partial class GeneratedIconSource
     /// 
     /// </summary>
     /// <returns></returns>
-    [SupportedOSPlatform("windows")]
+    [SupportedOSPlatform("windows5.0")]
     public Icon ToIcon()
     {
-        using var bitmap = Generate();
+        using var bitmap = GenerateIconBitmap();
 
         return Icon.FromHandle(bitmap.GetHicon());
     }
@@ -18,12 +18,43 @@ public sealed partial class GeneratedIconSource
     /// 
     /// </summary>
     /// <returns></returns>
-    [SupportedOSPlatform("windows")]
+    [SupportedOSPlatform("windows5.0")]
     public async Task<Icon> ToIconAsync(CancellationToken cancellationToken = default)
+    {
+        using var bitmap = await GenerateIconBitmapAsync(cancellationToken).ConfigureAwait(true);
+
+        return Icon.FromHandle(bitmap.GetHicon());
+    }
+
+    [SupportedOSPlatform("windows5.0")]
+    private Bitmap GenerateIconBitmap()
+    {
+        using var bitmap = Generate();
+
+        return ResizeToRequiredIconSize(bitmap);
+    }
+
+    [SupportedOSPlatform("windows5.0")]
+    private async Task<Bitmap> GenerateIconBitmapAsync(CancellationToken cancellationToken = default)
     {
         using var bitmap = await GenerateAsync(cancellationToken).ConfigureAwait(true);
 
-        return Icon.FromHandle(bitmap.GetHicon());
+        return ResizeToRequiredIconSize(bitmap);
+    }
+
+    [SupportedOSPlatform("windows5.0")]
+    private static Bitmap ResizeToRequiredIconSize(Bitmap bitmap)
+    {
+        var size = H.NotifyIcon.Interop.IconUtilities.GetRequiredCustomIconSize(largeIcon: false);
+        if (bitmap.Width == size.Width &&
+            bitmap.Height == size.Height)
+        {
+            return (Bitmap)bitmap.Clone();
+        }
+
+        return new Bitmap(
+            original: bitmap,
+            newSize: size);
     }
 
     [SupportedOSPlatform("windows")]


### PR DESCRIPTION
## Summary

Fixes generated System.Drawing tray icons that render correctly as bitmaps but appear cropped or wrong once converted to an HICON for the Windows shell.

The generated source bitmap is still rendered at the requested `GeneratedIconSource.Size`, but `ToIcon()` and `ToIconAsync()` now resize the temporary bitmap used for `GetHicon()` to the shell-required small icon size before creating the icon handle. This keeps `ToBitmap()` unchanged while making HICON output suitable for tray usage.

Closes #157.

## Validation

- `dotnet build src\libs\H.NotifyIcon.Wpf\H.NotifyIcon.Wpf.csproj --configuration Release --nologo`
- `dotnet build src\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj --configuration Release -p:Platform=x64 -p:WindowsPackageType=None --nologo`
- `dotnet build src\apps\H.NotifyIcon.Apps.Wpf\H.NotifyIcon.Apps.Wpf.csproj --configuration Release --nologo`
- Local repro: generated Segoe MDL2 `\uE83F` with 128px canvas and 64px font, then drew `GeneratedIconSource.ToIcon()` output successfully as a small icon (`40x40` on this machine, 136 non-transparent pixels).
- Computer Use smoke: WPF generated-icon context menu tutorial opened and rendered.
- Computer Use smoke: WinUI sample launched and rendered.