### PR TITLE
[codex] Sign extend tray callback coordinates

### DIFF
--- a/src/libs/H.NotifyIcon/Core/MessageWindow.cs
+++ b/src/libs/H.NotifyIcon/Core/MessageWindow.cs
@@ -167,7 +167,11 @@ public partial class MessageWindow : IDisposable
 
     private static Point ToPoint(nuint value)
     {
-        return new Point((int)value & 0xFFFF, ((int)value >> 16) & 0xFFFF);
+        var packed = unchecked((uint)value);
+
+        return new Point(
+            x: unchecked((short)(packed & 0xFFFF)),
+            y: unchecked((short)((packed >> 16) & 0xFFFF)));
     }
 
     /// <summary>

--- a/src/tests/H.NotifyIcon.IntegrationTests/TrayIconTests.cs
+++ b/src/tests/H.NotifyIcon.IntegrationTests/TrayIconTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.Reflection;
 using H.NotifyIcon.Core;
 
 namespace H.NotifyIcon.IntegrationTests;
@@ -16,6 +17,19 @@ public class TrayIconTests
         trayIcon.ShowContextMenu();
 
         wasRaised.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void MessageWindowCallbackPointSupportsNegativeVirtualScreenCoordinates()
+    {
+        var method = typeof(MessageWindow).GetMethod(
+            name: "ToPoint",
+            bindingAttr: BindingFlags.Static | BindingFlags.NonPublic);
+        var packed = unchecked((uint)((ushort)-120 | ((ushort)-80 << 16)));
+
+        var point = (Point)method!.Invoke(null, [new UIntPtr(packed)])!;
+
+        point.Should().Be(new Point(-120, -80));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fixes tray mouse callback coordinates on virtual desktops where the tray is on a monitor left of or above the primary display.

Windows packs the tray callback point into signed 16-bit X/Y values. `MessageWindow.ToPoint` previously decoded those words as unsigned values, so negative virtual-screen coordinates became large positive coordinates. WPF context menus using those coordinates could then open on the wrong monitor, matching the multi-display reports.

Closes #53.

## Validation

- `dotnet build src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.Wpf\H.NotifyIcon.Apps.Wpf.csproj --configuration Release --nologo`
- Added regression coverage for packed negative virtual-screen coordinates.
- Computer Use smoke: WPF sample launched and the context-menu tutorial opened/rendered normally.