### PR TITLE
[codex] Preload SecondWindow context menu host

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -14,6 +14,7 @@ public partial class TaskbarIcon
 
     private bool IsContextMenuVisible { get; set; }
     private bool IsSecondWindowContextMenuOpenEventRaised { get; set; }
+    private bool IsSecondWindowContextMenuLoaded { get; set; }
     private Window? ContextMenuWindow { get; set; }
     private nint? ContextMenuWindowHandle { get; set; }
     private AppWindow? ContextMenuAppWindow { get; set; }
@@ -43,6 +44,7 @@ public partial class TaskbarIcon
         }
 
         SynchronizeSecondWindowContextMenuItems();
+        EnsureSecondWindowContextMenuLoaded();
 
         var size = MeasureFlyout(ContextMenuFlyout, new Size(10000.0, 10000.0));
         var rasterizationScale = ContextMenuWindow.Content.XamlRoot?.RasterizationScale ?? 1.0;
@@ -97,6 +99,19 @@ public partial class TaskbarIcon
         }
     }
 
+    private void EnsureSecondWindowContextMenuLoaded()
+    {
+        if (IsSecondWindowContextMenuLoaded ||
+            ContextMenuWindow == null ||
+            ContextMenuWindowHandle == null)
+        {
+            return;
+        }
+
+        ContextMenuWindow.Activate();
+        _ = WindowUtilities.HideWindow(ContextMenuWindowHandle.Value);
+    }
+
     private static System.Drawing.Rectangle CreateTrayCursorExcludeRect(
         System.Drawing.Point cursorPosition,
         double rasterizationScale)
@@ -136,6 +151,8 @@ public partial class TaskbarIcon
         {
             return;
         }
+
+        IsSecondWindowContextMenuLoaded = false;
 
         var frame = new Frame
         {
@@ -222,6 +239,8 @@ public partial class TaskbarIcon
 
         frame.Loaded += (_, _) =>
         {
+            IsSecondWindowContextMenuLoaded = true;
+
             // Set the window style to PopupWindow to make the title bar invisible
             if (ContextMenuWindowHandle != null)
             {
@@ -233,6 +252,7 @@ public partial class TaskbarIcon
                 ShowMode = FlyoutShowMode.Transient,
             });
             flyout.Hide();
+            _ = WindowUtilities.HideWindow(handle);
         };
         window.Activated += (sender, args) =>
         {
@@ -260,6 +280,8 @@ public partial class TaskbarIcon
 #if !HAS_UNO
         ContextMenuAppWindow = appWindow;
 #endif
+
+        EnsureSecondWindowContextMenuLoaded();
     }
 
     private void SynchronizeSecondWindowContextMenuItems()


### PR DESCRIPTION
## Summary

Fixes the first-open SecondWindow context menu sizing path by loading and warming the hidden WinUI host window when the context menu window is prepared.

Previously the hidden second window could remain unloaded until the first tray click. That meant the first call to measure and show the flyout could happen before the host had a `XamlRoot` and before the warm-up `ShowAt`/`Hide` pass ran, producing first-open size differences and scrollbars. The host now activates once during preparation, hides immediately after warm-up, and resets the loaded flag when a new context flyout is prepared.

Closes #21.

## Validation

- `dotnet build src\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj --configuration Release --nologo`
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet build src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj --configuration Release -p:Platform=x64 -p:WindowsPackageType=None --nologo`
- Computer Use smoke: WinUI sample launched and rendered; only the intended `WinUI Desktop` window was visible after the hidden host preload.