### PR TITLE
Host WinUI tray popups in a hidden window

### DIFF
--- a/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml
+++ b/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml
@@ -50,6 +50,10 @@
                 Content="Clear notifications"
                 Click="ClearNotificationsButton_Click"
                 />
+            <Button
+                Content="Show tray popup"
+                Click="ShowTrayPopupButton_Click"
+                />
         </StackPanel>
     </Grid>
 </Page>

--- a/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml.cs
+++ b/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml.cs
@@ -40,4 +40,9 @@ public sealed partial class NotificationView
     {
         TrayIcon?.ClearNotifications();
     }
+
+    private void ShowTrayPopupButton_Click(object sender, RoutedEventArgs e)
+    {
+        TrayIcon?.ShowTrayPopup(new System.Drawing.Point(120, 120));
+    }
 }

--- a/src/apps/H.NotifyIcon.Apps.WinUI/Views/TrayIconView.xaml
+++ b/src/apps/H.NotifyIcon.Apps.WinUI/Views/TrayIconView.xaml
@@ -22,8 +22,31 @@
         IconSource="{x:Bind IsWindowVisible, Converter={StaticResource BoolToImageSourceConverter}}"
         LeftClickCommand="{x:Bind ShowHideWindowCommand}"
         NoLeftClickDelay="True"
+        PopupActivation="MiddleClick"
         ToolTipText="ToolTip"
         >
+        <tb:TaskbarIcon.TrayPopup>
+            <Border
+                MinWidth="240"
+                Padding="16"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="8"
+                >
+                <StackPanel Spacing="8">
+                    <TextBlock
+                        FontSize="16"
+                        FontWeight="SemiBold"
+                        Text="Tray Popup"
+                        />
+                    <TextBlock
+                        Text="WinUI content hosted by H.NotifyIcon."
+                        TextWrapping="Wrap"
+                        />
+                </StackPanel>
+            </Border>
+        </tb:TaskbarIcon.TrayPopup>
         <tb:TaskbarIcon.ContextFlyout>
             <MenuFlyout AreOpenCloseAnimationsEnabled="False">
                 <MenuFlyoutItem

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
@@ -125,6 +125,15 @@ public partial class TaskbarIcon : IDisposable
 #endif
 
 #if !HAS_WPF && !HAS_UNO && !HAS_MAUI
+#if HAS_WINUI
+            CloseTrayPopupWindow();
+            TrayPopupWindow?.Close();
+            TrayPopupWindow = null;
+            TrayPopupWindowHandle = null;
+            TrayPopupAppWindow = null;
+            TrayPopupWindowRoot = null;
+
+#endif
             CloseSecondWindowContextMenu();
             ContextMenuWindow?.Close();
             ContextMenuWindow = null;

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Popups.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Popups.cs
@@ -1,5 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
+#if HAS_WINUI
+using H.NotifyIcon.Interop;
+#endif
+
 namespace H.NotifyIcon;
 
 #if !HAS_MAUI
@@ -26,6 +30,15 @@ namespace H.NotifyIcon;
 public partial class TaskbarIcon
 {
     #region Properties
+
+#if HAS_WINUI
+    private bool IsTrayPopupVisible { get; set; }
+    private bool IsTrayPopupWindowLoaded { get; set; }
+    private Window? TrayPopupWindow { get; set; }
+    private nint? TrayPopupWindowHandle { get; set; }
+    private AppWindow? TrayPopupAppWindow { get; set; }
+    private FrameworkElement? TrayPopupWindowRoot { get; set; }
+#endif
 
     #region TrayPopup
 
@@ -72,6 +85,9 @@ public partial class TaskbarIcon
     [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(Popup))]
     private void CreatePopup()
     {
+#if HAS_WINUI
+        CreateTrayPopupWindow();
+#else
         // check if the item itself is a popup
         var popup = TrayPopup as Popup;
 
@@ -108,6 +124,7 @@ public partial class TaskbarIcon
 
         // store a reference to the used tooltip
         TrayPopupResolved = popup;
+#endif
     }
 
     /// <summary>
@@ -133,10 +150,14 @@ public partial class TaskbarIcon
             return;
         }
 
+#if HAS_WINUI
+        CloseTrayPopupWindow();
+#else
         if (TrayPopupResolved != null)
         {
             TrayPopupResolved.IsOpen = false;
         }
+#endif
     }
 
     /// <summary>
@@ -163,6 +184,12 @@ public partial class TaskbarIcon
         {
             return;
         }
+#if HAS_WINUI
+        if (!ShowTrayPopupWindow(cursorPosition))
+        {
+            return;
+        }
+#else
         if (TrayPopupResolved == null)
         {
             return;
@@ -199,6 +226,7 @@ public partial class TaskbarIcon
         TrayPopup?.RaiseEvent(new RoutedEventArgs(PopupOpenedEvent));
 #endif
 
+#endif
         // bubble routed event
         OnTrayPopupOpen();
     }
@@ -237,6 +265,195 @@ public partial class TaskbarIcon
         TrayPopupResolved.HorizontalOffset += PopupOffset.Left;
         TrayPopupResolved.VerticalOffset += PopupOffset.Top;
     }
+
+#if HAS_WINUI
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(OverlappedPresenter))]
+    private void CreateTrayPopupWindow()
+    {
+        CloseTrayPopupWindow();
+        TrayPopupWindow?.Close();
+        TrayPopupWindow = null;
+        TrayPopupWindowHandle = null;
+        TrayPopupAppWindow = null;
+        TrayPopupWindowRoot = null;
+        TrayPopupResolved = null;
+        IsTrayPopupWindowLoaded = false;
+
+        if (TrayPopup == null)
+        {
+            return;
+        }
+
+        if (TrayPopup is FrameworkElement element)
+        {
+            UpdateDataContext(element, DataContext);
+        }
+
+        var root = new Grid
+        {
+            Background = new SolidColorBrush(Colors.Transparent),
+        };
+        root.Children.Add(TrayPopup);
+
+        var window = new Window
+        {
+            Content = root,
+        };
+
+        var handle = WindowNative.GetWindowHandle(window);
+        if (TrayIcon.WindowHandle != 0)
+        {
+            HwndUtilities.SetOwnerWindow(handle, TrayIcon.WindowHandle);
+        }
+
+#if !HAS_UNO
+        var id = Win32Interop.GetWindowIdFromWindow(handle);
+        var appWindow = AppWindow.GetFromWindowId(id);
+        appWindow.IsShownInSwitchers = false;
+
+        var presenter = (OverlappedPresenter)appWindow.Presenter;
+        presenter.IsMaximizable = false;
+        presenter.IsMinimizable = false;
+        presenter.IsResizable = false;
+        presenter.IsAlwaysOnTop = true;
+        presenter.SetBorderAndTitleBar(false, false);
+#endif
+
+        root.Loaded += (_, _) =>
+        {
+            IsTrayPopupWindowLoaded = true;
+            HwndUtilities.SetWindowStyleAsPopupWindow(handle);
+            _ = WindowUtilities.HideWindow(handle);
+        };
+        window.Activated += (_, args) =>
+        {
+            if (args.WindowActivationState == WindowActivationState.Deactivated &&
+                IsTrayPopupVisible)
+            {
+                CloseTrayPopupWindow();
+            }
+        };
+
+        TrayPopupWindow = window;
+        TrayPopupWindowHandle = handle;
+#if !HAS_UNO
+        TrayPopupAppWindow = appWindow;
+#endif
+        TrayPopupWindowRoot = root;
+    }
+
+    private bool ShowTrayPopupWindow(System.Drawing.Point cursorPosition)
+    {
+        if (TrayPopupWindow == null ||
+            TrayPopupWindowHandle == null ||
+            TrayPopupWindowRoot == null)
+        {
+            return false;
+        }
+
+        EnsureTrayPopupWindowLoaded();
+
+        var size = MeasureTrayPopup(TrayPopupWindowRoot);
+        var anchor = GetTrayPopupAnchor(cursorPosition);
+        var rasterizationScale = TrayPopupWindowRoot.XamlRoot?.RasterizationScale ?? 1.0;
+        var rectangle = CursorUtilities.CalculatePopupWindowPosition(
+            anchor.X,
+            anchor.Y,
+            (int)size.Width,
+            (int)size.Height,
+            CreateTrayPopupExcludeRect(anchor, rasterizationScale));
+
+        IsTrayPopupVisible = true;
+        TrayPopupAppWindow?.MoveAndResize(rectangle.ToRectInt32());
+        _ = WindowUtilities.ShowWindow(TrayPopupWindowHandle.Value);
+        _ = WindowUtilities.SetForegroundWindow(TrayPopupWindowHandle.Value);
+
+        return true;
+    }
+
+    private void EnsureTrayPopupWindowLoaded()
+    {
+        if (IsTrayPopupWindowLoaded ||
+            TrayPopupWindow == null ||
+            TrayPopupWindowHandle == null)
+        {
+            return;
+        }
+
+        TrayPopupAppWindow?.MoveAndResize(CreateRectInt32(
+            x: -32000,
+            y: -32000,
+            width: 1,
+            height: 1));
+        TrayPopupWindow.Activate();
+        _ = WindowUtilities.HideWindow(TrayPopupWindowHandle.Value);
+    }
+
+    private void CloseTrayPopupWindow()
+    {
+        IsTrayPopupVisible = false;
+
+        if (TrayPopupWindowHandle is { } handle)
+        {
+            _ = WindowUtilities.HideWindow(handle);
+        }
+    }
+
+    private static Size MeasureTrayPopup(UIElement popup)
+    {
+        popup.Measure(new Size(10000.0, 10000.0));
+
+        var scale = popup.XamlRoot?.RasterizationScale ?? 1.0;
+
+        return new Size(
+            width: Math.Max(1.0, Math.Ceiling(popup.DesiredSize.Width * scale)),
+            height: Math.Max(1.0, Math.Ceiling(popup.DesiredSize.Height * scale)));
+    }
+
+    private System.Drawing.Point GetTrayPopupAnchor(System.Drawing.Point cursorPosition)
+    {
+        var point = PopupPlacement == PlacementMode.Bottom
+            ? TrayInfo.GetTrayLocation(0)
+            : cursorPosition;
+
+        return new System.Drawing.Point(
+            x: point.X + (int)Math.Round(PopupOffset.Left),
+            y: point.Y + (int)Math.Round(PopupOffset.Top));
+    }
+
+    private static System.Drawing.Rectangle CreateTrayPopupExcludeRect(
+        System.Drawing.Point cursorPosition,
+        double rasterizationScale)
+    {
+        var width = Math.Max(1, (int)Math.Round(36 * rasterizationScale));
+        var height = Math.Max(1, (int)Math.Round(36 * rasterizationScale));
+
+        return new System.Drawing.Rectangle(
+            x: cursorPosition.X - (width / 2),
+            y: cursorPosition.Y - (height / 2),
+            width: width,
+            height: height);
+    }
+
+    private static RectInt32 CreateRectInt32(int x, int y, int width, int height)
+    {
+#if HAS_UNO
+        return new RectInt32
+        {
+            X = x,
+            Y = y,
+            Width = width,
+            Height = height,
+        };
+#else
+        return new RectInt32(
+            _X: x,
+            _Y: y,
+            _Width: width,
+            _Height: height);
+#endif
+    }
+#endif
 
     #endregion
 }

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Properties.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Properties.cs
@@ -147,7 +147,11 @@ public partial class TaskbarIcon
 
     partial void OnDataContextChanged(object? newValue)
     {
+#if HAS_WINUI
+        UpdateDataContext(TrayPopup as FrameworkElement, newValue);
+#else
         UpdateDataContext(TrayPopupResolved, newValue);
+#endif
         UpdateDataContext(TrayToolTipResolved, newValue);
 #if HAS_WPF
         UpdateDataContext(ContextMenu, newValue);

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ToolTips.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ToolTips.cs
@@ -90,7 +90,11 @@ public partial class TaskbarIcon
             var balloon = (Popup?)null;
 #endif
 
-            return popup is { IsOpen: true } ||
+            return
+#if HAS_WINUI
+                   IsTrayPopupVisible ||
+#endif
+                   popup is { IsOpen: true } ||
                    menu is { IsOpen: true } ||
                    balloon is { IsOpen: true };
 #endif


### PR DESCRIPTION
## Summary
- host WinUI TrayPopup content in an owned hidden Window instead of a detached Popup
- wire popup visibility into tooltip suppression, data context propagation, and disposal cleanup
- add a WinUI sample popup plus a visible smoke-test button

Closes #57

## Validation
- dotnet build src\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj --configuration Release --nologo
- dotnet build src\libs\H.NotifyIcon.Uno.WinUI\H.NotifyIcon.Uno.WinUI.csproj --configuration Release --nologo
- dotnet build src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj --configuration Release -p:Platform=x64 -p:WindowsPackageType=None --nologo
- computer-use smoke: launched the WinUI sample, clicked Show tray popup, verified the secondary popup host rendered Tray Popup content, and verified it closed on deactivation
- dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo
- dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"