### PR TITLE
Support themed native tray context menus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,8 @@ At the moment, three modes are implemented, each with its own pros and cons.
 3. A second transparent window will be created and used to render the native menu. At the moment it is in the preview stage. To do this you need to explicitly set ContextMenuMode="SecondWindow"\
    ![image](https://user-images.githubusercontent.com/3002068/164977343-fab0ef4d-d1bd-4ff0-a1af-1d87f32c6400.png)
 
+Native `PopupMenu` mode follows the Windows app theme by default. Use `ContextMenuThemeMode="Light"`, `ContextMenuThemeMode="Dark"`, or `ContextMenuThemeMode="Default"` to override this behavior. Direct `H.NotifyIcon.Core.PopupMenu` users can set the same behavior with the `ThemeMode` property.
+
 Availability of various options(depends on the version of `WindowsAppSDK` you are using):
 
 | Option       | Packaged App          | Unpackaged App        |

--- a/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml
+++ b/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml
@@ -54,6 +54,10 @@
                 Content="Show tray popup"
                 Click="ShowTrayPopupButton_Click"
                 />
+            <Button
+                Content="Show native context menu"
+                Click="ShowNativeContextMenuButton_Click"
+                />
         </StackPanel>
     </Grid>
 </Page>

--- a/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml.cs
+++ b/src/apps/H.NotifyIcon.Apps.WinUI/Views/NotificationView.xaml.cs
@@ -45,4 +45,23 @@ public sealed partial class NotificationView
     {
         TrayIcon?.ShowTrayPopup(new System.Drawing.Point(120, 120));
     }
+
+    private void ShowNativeContextMenuButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (TrayIcon == null)
+        {
+            return;
+        }
+
+        var contextMenuMode = TrayIcon.ContextMenuMode;
+        try
+        {
+            TrayIcon.ContextMenuMode = ContextMenuMode.PopupMenu;
+            TrayIcon.ShowContextMenu(new System.Drawing.Point(120, 120));
+        }
+        finally
+        {
+            TrayIcon.ContextMenuMode = contextMenuMode;
+        }
+    }
 }

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.PopupMenu.cs
@@ -15,7 +15,8 @@ public partial class TaskbarIcon
     {
         var menu = new H.NotifyIcon.Core.PopupMenu
         {
-            RightToLeft = FlowDirection == FlowDirection.RightToLeft
+            RightToLeft = FlowDirection == FlowDirection.RightToLeft,
+            ThemeMode = ContextMenuThemeMode,
         };
 #if HAS_MAUI
         PopulateMenu(menu.Items, (MenuFlyout)ContextFlyout);

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinRT.cs
@@ -4,6 +4,8 @@ namespace H.NotifyIcon;
 
 [DependencyProperty<ContextMenuMode>("ContextMenuMode", DefaultValue = ContextMenuMode.PopupMenu,
     Description = "Defines the context menu mode.", Category = CategoryName)]
+[DependencyProperty<PopupMenuThemeMode>("ContextMenuThemeMode", DefaultValue = PopupMenuThemeMode.System,
+    Description = "Defines how tray context menus select their light or dark theme.", Category = CategoryName)]
 [DependencyProperty<bool>("CloseContextMenuOnItemClick", DefaultValue = true,
     Description = "Defines whether the second-window context menu closes after a menu item is clicked.", Category = CategoryName)]
 public partial class TaskbarIcon

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -30,6 +30,11 @@ public partial class TaskbarIcon
         }
     }
 
+    partial void OnContextMenuThemeModeChanged(PopupMenuThemeMode oldValue, PopupMenuThemeMode newValue)
+    {
+        ApplySecondWindowContextMenuTheme(ContextMenuWindow?.Content as FrameworkElement);
+    }
+
     #endregion
     
     #region Methods
@@ -172,7 +177,14 @@ public partial class TaskbarIcon
             Content = frame,
         };
 
-        ActualThemeChanged += (_, _) => frame.RequestedTheme = ActualTheme;
+        ApplySecondWindowContextMenuTheme(frame);
+        ActualThemeChanged += (_, _) =>
+        {
+            if (ContextMenuThemeMode == PopupMenuThemeMode.System)
+            {
+                ApplySecondWindowContextMenuTheme(frame);
+            }
+        };
 
         var handle = WindowNative.GetWindowHandle(window);
         DesktopWindowsManagerMethods.SetRoundedCorners(handle);
@@ -282,6 +294,22 @@ public partial class TaskbarIcon
 #endif
 
         EnsureSecondWindowContextMenuLoaded();
+    }
+
+    private void ApplySecondWindowContextMenuTheme(FrameworkElement? target)
+    {
+        if (target == null)
+        {
+            return;
+        }
+
+        target.RequestedTheme = ContextMenuThemeMode switch
+        {
+            PopupMenuThemeMode.System => ActualTheme,
+            PopupMenuThemeMode.Light => ElementTheme.Light,
+            PopupMenuThemeMode.Dark => ElementTheme.Dark,
+            _ => ElementTheme.Default,
+        };
     }
 
     private void SynchronizeSecondWindowContextMenuItems()

--- a/src/libs/H.NotifyIcon/Interop/NativeThemeUtilities.cs
+++ b/src/libs/H.NotifyIcon/Interop/NativeThemeUtilities.cs
@@ -1,0 +1,47 @@
+using System.Runtime.InteropServices;
+using H.NotifyIcon.Core;
+
+namespace H.NotifyIcon.Interop;
+
+internal static class NativeThemeUtilities
+{
+    public static void ApplyMenuTheme(PopupMenuThemeMode themeMode)
+    {
+        try
+        {
+            _ = SetPreferredAppMode(themeMode switch
+            {
+                PopupMenuThemeMode.System => PreferredAppMode.AllowDark,
+                PopupMenuThemeMode.Light => PreferredAppMode.ForceLight,
+                PopupMenuThemeMode.Dark => PreferredAppMode.ForceDark,
+                _ => PreferredAppMode.Default,
+            });
+            FlushMenuThemes();
+        }
+        catch (DllNotFoundException)
+        {
+        }
+        catch (EntryPointNotFoundException)
+        {
+        }
+        catch (BadImageFormatException)
+        {
+        }
+    }
+
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [DllImport("uxtheme.dll", EntryPoint = "#135", ExactSpelling = true)]
+    private static extern PreferredAppMode SetPreferredAppMode(PreferredAppMode preferredAppMode);
+
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [DllImport("uxtheme.dll", EntryPoint = "#136", ExactSpelling = true)]
+    private static extern void FlushMenuThemes();
+
+    private enum PreferredAppMode
+    {
+        Default,
+        AllowDark,
+        ForceDark,
+        ForceLight,
+    }
+}

--- a/src/libs/H.NotifyIcon/PopupMenus/PopupMenu.cs
+++ b/src/libs/H.NotifyIcon/PopupMenus/PopupMenu.cs
@@ -22,6 +22,11 @@ public class PopupMenu
     public bool RightToLeft { get; set; }
 
     /// <summary>
+    /// Gets or sets how the native popup menu should select its light or dark theme.
+    /// </summary>
+    public PopupMenuThemeMode ThemeMode { get; set; } = PopupMenuThemeMode.System;
+
+    /// <summary>
     /// 
     /// </summary>
     /// <param name="ownerHandle"></param>
@@ -30,6 +35,8 @@ public class PopupMenu
     /// <exception cref="NotImplementedException"></exception>
     public void Show(nint ownerHandle, int x, int y)
     {
+        NativeThemeUtilities.ApplyMenuTheme(ThemeMode);
+
         var flags =
            TRACK_POPUP_MENU_FLAGS.TPM_RETURNCMD |
            TRACK_POPUP_MENU_FLAGS.TPM_NONOTIFY |

--- a/src/libs/H.NotifyIcon/PopupMenus/PopupMenuThemeMode.cs
+++ b/src/libs/H.NotifyIcon/PopupMenus/PopupMenuThemeMode.cs
@@ -1,0 +1,28 @@
+namespace H.NotifyIcon.Core;
+
+/// <summary>
+/// Defines how native popup menus should select their light or dark theme.
+/// </summary>
+public enum PopupMenuThemeMode
+{
+    /// <summary>
+    /// Uses the Windows default native menu app mode.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Allows native popup menus to follow the current Windows app theme.
+    /// This is the default value.
+    /// </summary>
+    System,
+
+    /// <summary>
+    /// Forces native popup menus to use a light theme when supported by Windows.
+    /// </summary>
+    Light,
+
+    /// <summary>
+    /// Forces native popup menus to use a dark theme when supported by Windows.
+    /// </summary>
+    Dark,
+}


### PR DESCRIPTION
## Summary
- add PopupMenuThemeMode for native popup menus with System/Light/Dark/Default options
- apply SetPreferredAppMode/FlushMenuThemes before native HMENU display so PopupMenu mode can follow Windows app theme by default
- expose ContextMenuThemeMode on TaskbarIcon and apply it to both PopupMenu and WinUI SecondWindow context menus
- add a WinUI sample button and README note for native context-menu theme testing

Closes #117

## Validation
- dotnet build src\libs\H.NotifyIcon\H.NotifyIcon.csproj --configuration Release --nologo
- dotnet build src\libs\H.NotifyIcon.WinUI\H.NotifyIcon.WinUI.csproj --configuration Release --nologo
- dotnet build src\libs\H.NotifyIcon.Uno.WinUI\H.NotifyIcon.Uno.WinUI.csproj --configuration Release --nologo
- dotnet build src\libs\H.NotifyIcon.Maui\H.NotifyIcon.Maui.csproj --configuration Release --nologo
- dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo
- dotnet test src\tests\H.NotifyIcon.IntegrationTests\H.NotifyIcon.IntegrationTests.csproj --configuration Release --no-build --nologo --logger "console;verbosity=minimal"
- dotnet build src\apps\H.NotifyIcon.Apps.WinUI\H.NotifyIcon.Apps.WinUI.csproj --configuration Release -p:Platform=x64 -p:WindowsPackageType=None --nologo
- computer-use smoke: launched WinUI sample, clicked Show native context menu, verified the native PopupMenu rendered in the dark app/OS theme, then closed cleanly