### PR TITLE
docs: mention native context menu theme support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This is an implementation of a NotifyIcon (aka system tray icon or taskbar icon)
 #### Features
 
 * Notifications
-* [Context menus](#winui-context-menu)
+* [Context menus](#winui-context-menu), including native light/dark theme support
 * ICommand support
 * [Design-time access](#design-time-access)
 * [Efficiency Mode](#efficiency-mode)
@@ -153,7 +153,16 @@ At the moment, three modes are implemented, each with its own pros and cons.
 3. A second transparent window will be created and used to render the native menu. At the moment it is in the preview stage. To do this you need to explicitly set ContextMenuMode="SecondWindow"\
    ![image](https://user-images.githubusercontent.com/3002068/164977343-fab0ef4d-d1bd-4ff0-a1af-1d87f32c6400.png)
 
-Native `PopupMenu` mode follows the Windows app theme by default. Use `ContextMenuThemeMode="Light"`, `ContextMenuThemeMode="Dark"`, or `ContextMenuThemeMode="Default"` to override this behavior. Direct `H.NotifyIcon.Core.PopupMenu` users can set the same behavior with the `ThemeMode` property.
+Native `PopupMenu` mode follows the Windows app theme by default through `ContextMenuThemeMode="System"`. Use `ContextMenuThemeMode="Light"` or `ContextMenuThemeMode="Dark"` to force a specific native menu theme, or `ContextMenuThemeMode="Default"` to use the Windows default native menu app mode. The same property is also respected by `SecondWindow` mode for its WinUI flyout theme.
+
+```xml
+<tb:TaskbarIcon
+    ContextMenuMode="PopupMenu"
+    ContextMenuThemeMode="Dark"
+    />
+```
+
+Direct `H.NotifyIcon.Core.PopupMenu` users can set the same behavior with the `ThemeMode` property.
 
 Availability of various options(depends on the version of `WindowsAppSDK` you are using):
 


### PR DESCRIPTION
## Summary
- mention native light/dark theme support in the README feature list
- document `ContextMenuThemeMode` defaults and overrides for WinUI context menus
- add a compact XAML example for forcing a native dark tray context menu

## Validation
- `dotnet build H.NotifyIcon.PR.slnx --configuration Release --nologo`
- `git diff --check -- readme.md` (no whitespace errors; Git reported the existing CRLF checkout warning)