### PR TITLE
fix(winui): release second-window context menu

### DIFF
--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -39,7 +39,7 @@ public partial class TaskbarIcon
 
     partial void OnContextMenuThemeModeChanged(PopupMenuThemeMode oldValue, PopupMenuThemeMode newValue)
     {
-        ApplySecondWindowContextMenuTheme(ContextMenuWindow?.Content as FrameworkElement);
+        ApplySecondWindowContextMenuTheme(ContextMenuWindowRoot);
     }
 
     #endregion
@@ -123,12 +123,18 @@ public partial class TaskbarIcon
             flyout.Closing -= OnSecondWindowFlyoutClosing;
             flyout.Closed -= OnSecondWindowFlyoutClosed;
 
-            foreach (var item in flyout.Items)
+            var items = flyout.Items.ToList();
+            foreach (var item in items)
             {
                 item.Tapped -= OnSecondWindowContextMenuItemTapped;
-            }
+                _ = flyout.Items.Remove(item);
 
-            flyout.Items.Clear();
+                if (ContextFlyout is MenuFlyout sourceFlyout &&
+                    !sourceFlyout.Items.Contains(item))
+                {
+                    sourceFlyout.Items.Add(item);
+                }
+            }
         }
 
         if (ContextMenuWindowRoot is { } root)

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -16,6 +16,7 @@ public partial class TaskbarIcon
     private bool IsSecondWindowContextMenuOpenEventRaised { get; set; }
     private bool IsSecondWindowContextMenuLoaded { get; set; }
     private Window? ContextMenuWindow { get; set; }
+    private Frame? ContextMenuWindowRoot { get; set; }
     private nint? ContextMenuWindowHandle { get; set; }
     private AppWindow? ContextMenuAppWindow { get; set; }
     private MenuFlyout? ContextMenuFlyout { get; set; }
@@ -24,6 +25,12 @@ public partial class TaskbarIcon
     partial void OnContextMenuModeChanged(ContextMenuMode oldValue, ContextMenuMode newValue)
 #pragma warning restore CA1822 // Mark members as static
     {
+        if (oldValue is ContextMenuMode.SecondWindow &&
+            newValue is not ContextMenuMode.SecondWindow)
+        {
+            DisposeSecondWindowContextMenu();
+        }
+
         if (newValue is ContextMenuMode.SecondWindow)
         {
             PrepareContextMenuWindow();
@@ -104,6 +111,47 @@ public partial class TaskbarIcon
         }
     }
 
+    private void DisposeSecondWindowContextMenu()
+    {
+        CloseSecondWindowContextMenu();
+
+        ActualThemeChanged -= OnSecondWindowActualThemeChanged;
+
+        if (ContextMenuFlyout is { } flyout)
+        {
+            flyout.Opened -= OnSecondWindowFlyoutOpened;
+            flyout.Closing -= OnSecondWindowFlyoutClosing;
+            flyout.Closed -= OnSecondWindowFlyoutClosed;
+
+            foreach (var item in flyout.Items)
+            {
+                item.Tapped -= OnSecondWindowContextMenuItemTapped;
+            }
+
+            flyout.Items.Clear();
+        }
+
+        if (ContextMenuWindowRoot is { } root)
+        {
+            root.Loaded -= OnSecondWindowRootLoaded;
+            root.ClearValue(FlowDirectionProperty);
+        }
+
+        if (ContextMenuWindow is { } window)
+        {
+            window.Activated -= OnSecondWindowActivated;
+            window.Content = null;
+            window.Close();
+        }
+
+        IsSecondWindowContextMenuLoaded = false;
+        ContextMenuFlyout = null;
+        ContextMenuWindow = null;
+        ContextMenuWindowRoot = null;
+        ContextMenuWindowHandle = null;
+        ContextMenuAppWindow = null;
+    }
+
     private void EnsureSecondWindowContextMenuLoaded()
     {
         if (IsSecondWindowContextMenuLoaded ||
@@ -157,6 +205,7 @@ public partial class TaskbarIcon
             return;
         }
 
+        DisposeSecondWindowContextMenu();
         IsSecondWindowContextMenuLoaded = false;
 
         var frame = new Frame
@@ -178,13 +227,7 @@ public partial class TaskbarIcon
         };
 
         ApplySecondWindowContextMenuTheme(frame);
-        ActualThemeChanged += (_, _) =>
-        {
-            if (ContextMenuThemeMode == PopupMenuThemeMode.System)
-            {
-                ApplySecondWindowContextMenuTheme(frame);
-            }
-        };
+        ActualThemeChanged += OnSecondWindowActualThemeChanged;
 
         var handle = WindowNative.GetWindowHandle(window);
         DesktopWindowsManagerMethods.SetRoundedCorners(handle);
@@ -215,85 +258,110 @@ public partial class TaskbarIcon
             AreOpenCloseAnimationsEnabled = ContextFlyout.AreOpenCloseAnimationsEnabled,
             Placement = FlyoutPlacementMode.Full,
         };
-        flyout.Opened += (_, _) =>
-        {
-            if (IsContextMenuVisible &&
-                !IsSecondWindowContextMenuOpenEventRaised)
-            {
-                IsSecondWindowContextMenuOpenEventRaised = true;
-                _ = OnSecondWindowContextMenuOpened();
-            }
-        };
-        flyout.Closing += (_, args) =>
-        {
-            if (!CloseContextMenuOnItemClick &&
-                IsContextMenuVisible)
-            {
-                args.Cancel = true;
-            }
-        };
-        flyout.Closed += (_, _) =>
-        {
-            if (!flyout.AreOpenCloseAnimationsEnabled ||
-                !IsContextMenuVisible)
-            {
-                _ = WindowUtilities.HideWindow(handle);
-                return;
-            }
-
-            flyout.ShowAt(window.Content, new FlyoutShowOptions
-            {
-                ShowMode = FlyoutShowMode.Transient,
-            });
-        };
+        flyout.Opened += OnSecondWindowFlyoutOpened;
+        flyout.Closing += OnSecondWindowFlyoutClosing;
+        flyout.Closed += OnSecondWindowFlyoutClosed;
         ContextMenuFlyout = flyout;
         SynchronizeSecondWindowContextMenuItems();
 
-        frame.Loaded += (_, _) =>
-        {
-            IsSecondWindowContextMenuLoaded = true;
-
-            // Set the window style to PopupWindow to make the title bar invisible
-            if (ContextMenuWindowHandle != null)
-            {
-                HwndUtilities.SetWindowStyleAsPopupWindow(ContextMenuWindowHandle.Value);
-            }
-            
-            flyout.ShowAt(window.Content, new FlyoutShowOptions
-            {
-                ShowMode = FlyoutShowMode.Transient,
-            });
-            flyout.Hide();
-            _ = WindowUtilities.HideWindow(handle);
-        };
-        window.Activated += (sender, args) =>
-        {
-            if (args.WindowActivationState == WindowActivationState.Deactivated)
-            {
-                CloseSecondWindowContextMenu();
-                return;
-            }
-
-            if (ContextMenuWindow == null)
-            {
-                return;
-            }
-
-            if (!IsContextMenuVisible)
-            {
-                return;
-            }
-
-            ShowSecondWindowFlyout(flyout, window.Content);
-        };
+        frame.Loaded += OnSecondWindowRootLoaded;
+        window.Activated += OnSecondWindowActivated;
 
         ContextMenuWindow = window;
+        ContextMenuWindowRoot = frame;
         ContextMenuWindowHandle = handle;
 #if !HAS_UNO
         ContextMenuAppWindow = appWindow;
 #endif
 
         EnsureSecondWindowContextMenuLoaded();
+    }
+
+    private void OnSecondWindowActualThemeChanged(FrameworkElement sender, object args)
+    {
+        if (ContextMenuThemeMode == PopupMenuThemeMode.System)
+        {
+            ApplySecondWindowContextMenuTheme(ContextMenuWindowRoot);
+        }
+    }
+
+    private void OnSecondWindowFlyoutOpened(object? sender, object args)
+    {
+        if (IsContextMenuVisible &&
+            !IsSecondWindowContextMenuOpenEventRaised)
+        {
+            IsSecondWindowContextMenuOpenEventRaised = true;
+            _ = OnSecondWindowContextMenuOpened();
+        }
+    }
+
+    private void OnSecondWindowFlyoutClosing(FlyoutBase sender, FlyoutBaseClosingEventArgs args)
+    {
+        if (!CloseContextMenuOnItemClick &&
+            IsContextMenuVisible)
+        {
+            args.Cancel = true;
+        }
+    }
+
+    private void OnSecondWindowFlyoutClosed(object? sender, object args)
+    {
+        if (sender is not MenuFlyout flyout ||
+            !flyout.AreOpenCloseAnimationsEnabled ||
+            !IsContextMenuVisible)
+        {
+            if (ContextMenuWindowHandle is { } handle)
+            {
+                _ = WindowUtilities.HideWindow(handle);
+            }
+
+            return;
+        }
+
+        if (ContextMenuWindowRoot is { } root)
+        {
+            ShowSecondWindowFlyout(flyout, root);
+        }
+    }
+
+    private void OnSecondWindowRootLoaded(object sender, RoutedEventArgs args)
+    {
+        if (sender is not Frame root ||
+            ContextMenuFlyout is not { } flyout ||
+            ContextMenuWindowHandle is not { } handle)
+        {
+            return;
+        }
+
+        IsSecondWindowContextMenuLoaded = true;
+
+        // Set the window style to PopupWindow to make the title bar invisible
+        HwndUtilities.SetWindowStyleAsPopupWindow(handle);
+
+        flyout.ShowAt(root, new FlyoutShowOptions
+        {
+            ShowMode = FlyoutShowMode.Transient,
+        });
+        flyout.Hide();
+        _ = WindowUtilities.HideWindow(handle);
+    }
+
+    private void OnSecondWindowActivated(object sender, WindowActivatedEventArgs args)
+    {
+        if (args.WindowActivationState == WindowActivationState.Deactivated)
+        {
+            CloseSecondWindowContextMenu();
+            return;
+        }
+
+        if (!IsContextMenuVisible ||
+            ContextMenuFlyout is not { } flyout ||
+            ContextMenuWindowRoot is not { } root)
+        {
+            return;
+        }
+
+        ShowSecondWindowFlyout(flyout, root);
     }
 
     private void ApplySecondWindowContextMenuTheme(FrameworkElement? target)

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.ContextMenu.WinUI.SecondWindow.cs
@@ -19,6 +19,7 @@ public partial class TaskbarIcon
     private Frame? ContextMenuWindowRoot { get; set; }
     private nint? ContextMenuWindowHandle { get; set; }
     private AppWindow? ContextMenuAppWindow { get; set; }
+    private MenuFlyout? ContextMenuSourceFlyout { get; set; }
     private MenuFlyout? ContextMenuFlyout { get; set; }
 
 #pragma warning disable CA1822 // Mark members as static
@@ -129,7 +130,7 @@ public partial class TaskbarIcon
                 item.Tapped -= OnSecondWindowContextMenuItemTapped;
                 _ = flyout.Items.Remove(item);
 
-                if (ContextFlyout is MenuFlyout sourceFlyout &&
+                if (ContextMenuSourceFlyout is { } sourceFlyout &&
                     !sourceFlyout.Items.Contains(item))
                 {
                     sourceFlyout.Items.Add(item);
@@ -151,6 +152,7 @@ public partial class TaskbarIcon
         }
 
         IsSecondWindowContextMenuLoaded = false;
+        ContextMenuSourceFlyout = null;
         ContextMenuFlyout = null;
         ContextMenuWindow = null;
         ContextMenuWindowRoot = null;
@@ -205,13 +207,14 @@ public partial class TaskbarIcon
     [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof(MenuFlyoutSubItem))]
     private void PrepareContextMenuWindow()
     {
+        DisposeSecondWindowContextMenu();
+
         if (ContextFlyout == null ||
             ContextMenuMode != ContextMenuMode.SecondWindow)
         {
             return;
         }
 
-        DisposeSecondWindowContextMenu();
         IsSecondWindowContextMenuLoaded = false;
 
         var frame = new Frame
@@ -267,6 +270,7 @@ public partial class TaskbarIcon
         flyout.Opened += OnSecondWindowFlyoutOpened;
         flyout.Closing += OnSecondWindowFlyoutClosing;
         flyout.Closed += OnSecondWindowFlyoutClosed;
+        ContextMenuSourceFlyout = ContextFlyout as MenuFlyout;
         ContextMenuFlyout = flyout;
         SynchronizeSecondWindowContextMenuItems();
 

--- a/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
+++ b/src/libs/H.NotifyIcon.Shared/TaskbarIcon.Dispose.cs
@@ -134,11 +134,7 @@ public partial class TaskbarIcon : IDisposable
             TrayPopupWindowRoot = null;
 
 #endif
-            CloseSecondWindowContextMenu();
-            ContextMenuWindow?.Close();
-            ContextMenuWindow = null;
-            ContextMenuWindowHandle = null;
-            ContextMenuAppWindow = null;
+            DisposeSecondWindowContextMenu();
 #endif
 
             TrayIcon.Dispose();


### PR DESCRIPTION
## Summary\n\n- detach WinUI second-window flyout, window, theme, load, and item event handlers during teardown\n- clear the flow-direction binding and release the cloned flyout/window object graph\n- reuse teardown when replacing the context flyout or leaving SecondWindow mode\n\n## Validation\n\n- dotnet build src/libs/H.NotifyIcon.WinUI/H.NotifyIcon.WinUI.csproj --configuration Release -p:AppxGeneratePriEnabled=false -p:GeneratePackageOnBuild=false\n- build succeeded on macOS with 0 warnings and 0 errors\n- reviewed the PR diff for teardown ordering and scoped file ownership\n\nWindows runtime validation remains necessary for the reporter's forced-GC and handle-count canary.\n\nFixes #280